### PR TITLE
Request the token when selecting a Bond

### DIFF
--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -4,11 +4,13 @@ import bond.database
 from ..cli.console import LogLine
 from bond.proto import get_async
 
+
 def update_token_callback(bondid, rsp):
-    token = rsp.get('b', {}).get('token')
+    token = rsp.get("b", {}).get("token")
     if token:
         print(f"{bondid}'s token is unlocked, updating...")
         update_token(token)
+
 
 class SelectCommand(BaseCommand):
     subcmd = "select"
@@ -32,11 +34,10 @@ class SelectCommand(BaseCommand):
             if args.port:
                 bond.database.set_bond(args.BONDID, "port", args.port)
                 LogLine("Set %s port %s" % (args.BONDID, args.ip))
-            threads = get_async(args.BONDID,
-                topic="token",
-                on_success=update_token_callback,
+            threads = get_async(
+                args.BONDID, topic="token", on_success=update_token_callback
             )
-            
+
         if args.none:
             bond.database.set("selected_bondid", None)
         LogLine("Selected Bond: %s" % bond.database.get("selected_bondid"))

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -1,11 +1,18 @@
 from .base_command import BaseCommand
+from .token import update_token
 import bond.database
 from ..cli.console import LogLine
+from bond.proto import get_async
 
+def update_token_callback(bondid, rsp):
+    token = rsp.get('b', {}).get('token')
+    if token:
+        print(f"{bondid}'s token is unlocked, updating...")
+        update_token(token)
 
 class SelectCommand(BaseCommand):
     subcmd = "select"
-    help = "Select a single Bond to interact with."
+    help = "Select a single Bond to interact with. If the token of this Bond is unlocked, it will be set. (The easiest way to unlock a token is with a power cycle)"
     arguments = [
         (
             ["BONDID"],
@@ -25,6 +32,11 @@ class SelectCommand(BaseCommand):
             if args.port:
                 bond.database.set_bond(args.BONDID, "port", args.port)
                 LogLine("Set %s port %s" % (args.BONDID, args.ip))
+            threads = get_async(args.BONDID,
+                topic="token",
+                on_success=update_token_callback,
+            )
+            
         if args.none:
             bond.database.set("selected_bondid", None)
         LogLine("Selected Bond: %s" % bond.database.get("selected_bondid"))

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -2,6 +2,14 @@ from .base_command import BaseCommand
 import bond.database
 from bond.cli.console import LogLine
 
+def update_token(token):
+    bondid = bond.database.get_assert_selected_bondid()
+    bonds = bond.database.get_bonds()
+    if bondid not in bonds.keys():
+        bonds[bondid] = dict()
+    bonds[bondid]["token"] = token
+    print(f"Updated token for {bondid}")
+    bond.database.set("bonds", bonds)
 
 class TokenCommand(BaseCommand):
     subcmd = "token"
@@ -9,16 +17,7 @@ class TokenCommand(BaseCommand):
     arguments = [(["TOKEN"], {"help": "Save Bond token to local database"})]
 
     def run(self, args):
-        bondid = bond.database.get_assert_selected_bondid()
-        bonds = bond.database.get_bonds()
-        if bondid not in bonds.keys():
-            bonds[bondid] = dict()
-            LogLine("Adding new Bond to local database.")
-        else:
-            LogLine("Updating token for existing Bond.")
-        bonds[bondid]["token"] = args.TOKEN
-        bond.database.set("bonds", bonds)
-
+        update_token(args["Token"])
 
 def register():
     TokenCommand()

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -2,6 +2,7 @@ from .base_command import BaseCommand
 import bond.database
 from bond.cli.console import LogLine
 
+
 def update_token(token):
     bondid = bond.database.get_assert_selected_bondid()
     bonds = bond.database.get_bonds()
@@ -11,6 +12,7 @@ def update_token(token):
     print(f"Updated token for {bondid}")
     bond.database.set("bonds", bonds)
 
+
 class TokenCommand(BaseCommand):
     subcmd = "token"
     help = "Manage token-based authentication."
@@ -18,6 +20,7 @@ class TokenCommand(BaseCommand):
 
     def run(self, args):
         update_token(args["Token"])
+
 
 def register():
     TokenCommand()


### PR DESCRIPTION
Makes the `token` line unnecessary when interacting with a Bond with an unlocked token:
```
python -m bond select ZXBL12345
python -m bond token abcdabcdabcdabcd
python -m bond devices
```

Resolves https://github.com/bondhome/bond-cli/issues/8

Why did I not use `LogLine`? https://github.com/bondhome/bond-cli/issues/11