### PR TITLE
Fix the OTA upgrade command

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ bond livelog --level info
 You can upgrade your selected bond:
 
 ```bash
-bond upgrade --release beta
+bond upgrade beta
 ```
 
 ## Getting Help

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -56,8 +56,6 @@ class SelectCommand(BaseCommand):
                 print("Set %s port %s" % (bond_id, args.ip))
             print("Selected Bond: %s" % BondDatabase().get("selected_bondid"))
             token = check_unlocked_token()
-            if token:
-                print("Set token: %s" % token)
         elif args.clear:
             BondDatabase.pop("selected_bondid", None)
             print("Cleared selected Bond")

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -66,11 +66,12 @@ def do_upgrade(bondid, version_obj):
         # check for in progress return get on upgrade
         try:
             rsp = bond.proto.get(bondid, topic="sys/version", timeout=2)
-            print("Reconnected!")
-            break
-        except:
+        except requests.exceptions.ConnectTimeout:
             sys.stdout.write(".")
             sys.stdout.flush()
+            continue
+        print("Reconnected!")
+        break
     else:
         raise Exception("Download timeout")
 

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -41,13 +41,17 @@ def do_upgrade(bondid, version_obj):
         pass
     for _ in range(120):
         time.sleep(1)
-        rsp = bond.proto.get(bondid, topic="sys/upgrade")
-        progress = rsp["b"]["progress"]
-        assert rsp["s"] in (200, 204)
-        if rsp["s"] == 204 or progress == 1000:
-            print("Upgrade installed.")
-            break
-        print(f"Progress: {progress / 10}%")
+        try:
+            rsp = bond.proto.get(bondid, topic="sys/upgrade")
+            progress = rsp["b"]["progress"]
+            print(f"Progress: {progress / 10}%")
+            if rsp["s"] == 204 or progress == 1000:
+                print("Upgrade installed.")
+                break
+        except:
+            sys.stdout.write(".")
+            sys.stdout.flush()
+            pass
     else:
         raise Exception("Download timeout")
     print("Rebooting...")
@@ -61,14 +65,11 @@ def do_upgrade(bondid, version_obj):
         # check for in progress return get on upgrade
         try:
             rsp = bond.proto.get(bondid, topic="sys/version", timeout=2)
+            print("Reconnected!")
+            break
         except:
             sys.stdout.write(".")
             sys.stdout.flush()
-            rsp = None
-
-        if rsp:
-            print("Reconnected!")
-            break
     else:
         raise Exception("Download timeout")
 

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -44,15 +44,15 @@ def do_upgrade(bondid, version_obj):
         time.sleep(1)
         try:
             rsp = bond.proto.get(bondid, topic="sys/upgrade")
-            progress = rsp["b"]["progress"]
-            print(f"Progress: {progress / 10}%")
-            if rsp["s"] == 204 or progress == 1000:
-                print("Upgrade installed.")
-                break
-        except:
+        except requests.exceptions.ReadTimeout:
             sys.stdout.write(".")
             sys.stdout.flush()
-            pass
+            continue
+        progress = rsp["b"]["progress"]
+        print(f"Progress: {progress / 10}%")
+        if rsp["s"] == 204 or progress == 1000:
+            print("Upgrade installed.")
+            break
     else:
         raise Exception("Download timeout")
     print("Rebooting...")

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEPS_TEST = DEPS_ALL + open('requirements-test.txt').readlines()
 
 setup(
     name='bond-cli',
-    version='0.0.7',
+    version='0.0.8',
     author='Olibra',
     packages=find_packages(),
     scripts=['bond/bond'],


### PR DESCRIPTION
The first `rsp = bond.proto.get(bondid, topic="sys/upgrade")` would sometimes time out. This mess of `try: ... except: ...` is not ideal, but this is a critical function of this program, so I thought I'd get it up and working before the inevitable refactor.