### PR TITLE
Simplify Select/Token flow

### DIFF
--- a/bond/commands/list.py
+++ b/bond/commands/list.py
@@ -6,19 +6,20 @@ from bond.cli.table import Table
 class ListCommand(BaseCommand):
     subcmd = "list"
     help = "List Bonds in local database."
+    arguments = {"--clear": {"action": "store_true", "help": "clear discovered Bonds"}}
 
     def run(self, args):
-        table = Table(["bondid", "ip", "token"])
-        bonds = BondDatabase.get_bonds()
-        for bondid in bonds.keys():
-            b = bonds[bondid]
-            table.add_row(
-                {
-                    "bondid": bondid,
-                    "ip": b["ip"] if "ip" in b else None,
-                    "token": b["token"] if "token" in b else None,
-                }
-            )
+        if args.clear:
+            BondDatabase.pop("bonds", None)
+            print("Cleared discovered Bonds")
+        else:
+            table = Table(["bondid", "ip", "token"])
+            bonds = BondDatabase.get_bonds()
+            for bondid in bonds.keys():
+                b = bonds[bondid]
+                table.add_row(
+                    {"bondid": bondid, "ip": b.get("ip"), "token": b.get("token")}
+                )
 
 
 def register():

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -59,10 +59,7 @@ class LivelogCommand(BaseCommand):
             "help": "set the verbosity for the given subsys: warn, info, debug, or trace",
             "choices": LEVEL_MAP.keys(),
         },
-        "--out": {
-            "help": "a filename to write the logs to",
-            "default": os.devnull,
-        }
+        "--out": {"help": "a filename to write the logs to", "default": os.devnull},
     }
 
     def run(self, args):

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -75,20 +75,20 @@ class LivelogCommand(BaseCommand):
                 body["lvl"] = LEVEL_MAP[args.subsys_level]
             bond.proto.patch(bondid, topic="debug/syslog", body=body)
 
-        if args.ip is None:
-            with open(args.out, "w+") as log:
-                my_ip = get_my_ip(BondDatabase.get_bonds()[bondid]["ip"])
-                sock, UDP_PORT = listen(my_ip)
-                do_livelog(bondid, my_ip, UDP_PORT)
-                log.write("\n===== %s =====\n" % datetime.datetime.now())
-                while True:
-                    data, addr = sock.recvfrom(1024 * 16)
-                    logline = data.decode("utf-8")
-                    sys.stdout.write(logline)
-                    log.write(logline)
-                    log.flush()
-        else:
+        if args.ip:
             do_livelog(bond, args.ip, int(args.port))
+        else:
+            my_ip = get_my_ip(BondDatabase.get_bonds()[bondid]["ip"])
+            sock, UDP_PORT = listen(my_ip)
+            do_livelog(bondid, my_ip, UDP_PORT)
+        with open(args.out, "w+") as log:
+            log.write("\n===== %s =====\n" % datetime.datetime.now())
+            while True:
+                data, addr = sock.recvfrom(1024 * 16)
+                logline = data.decode("utf-8")
+                sys.stdout.write(logline)
+                log.write(logline)
+                log.flush()
 
 
 def register():

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -55,7 +55,9 @@ class SelectCommand(BaseCommand):
                 BondDatabase.set_bond(bond_id, "port", args.port)
                 print("Set %s port %s" % (bond_id, args.ip))
             print("Selected Bond: %s" % BondDatabase().get("selected_bondid"))
-            check_unlocked_token()
+            token = check_unlocked_token()
+            if token:
+                print("Set token: %s" % token)
         elif args.clear:
             BondDatabase.pop("selected_bondid", None)
             print("Cleared selected Bond")

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -1,22 +1,14 @@
 from .base_command import BaseCommand
-from .token import update_token
+from .token import check_unlocked_token
 from bond.database import BondDatabase
 from ..cli.console import LogLine
-from bond.proto import get_async
-
-
-def update_token_callback(bondid, rsp):
-    token = rsp.get("b", {}).get("token")
-    if token:
-        print(f"{bondid}'s token is unlocked, updating...")
-        update_token(token)
 
 
 class SelectCommand(BaseCommand):
     subcmd = "select"
     help = "Select a single Bond to interact with. If the token of this Bond is unlocked, it will be set. (The easiest way to unlock a token is with a power cycle)"
     arguments = {
-        "BONDID": {
+        "bond_id": {
             "nargs": "?",
             "help": "Bond ID to interact with in subsequent commands",
         },
@@ -26,18 +18,15 @@ class SelectCommand(BaseCommand):
     }
 
     def run(self, args):
-        if args.BONDID:
-            BondDatabase.set("selected_bondid", args.BONDID)
+        if args.bond_id:
+            BondDatabase.set("selected_bondid", args.bond_id)
             if args.ip:
                 BondDatabase.set_bond(args.BONDID, "ip", args.ip)
                 LogLine("Set %s IP %s" % (args.BONDID, args.ip))
             if args.port:
                 BondDatabase.set_bond(args.BONDID, "port", args.port)
                 LogLine("Set %s port %s" % (args.BONDID, args.ip))
-            threads = get_async(
-                args.BONDID, topic="token", on_success=update_token_callback
-            )
-
+            check_unlocked_token()
         if args.none:
             BondDatabase.set("selected_bondid", None)
         LogLine("Selected Bond: %s" % BondDatabase.get("selected_bondid"))

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -43,7 +43,7 @@ class SelectCommand(BaseCommand):
             if len(matches) == 1:
                 bond_id = matches[0]
             if len(matches) > 1:
-                print("Found multiple possibilities:")
+                print("Ambiguous Bond ID prefix. Potential matches:")
                 for match in matches:
                     print(match)
                 exit(1)

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -6,30 +6,59 @@ from ..cli.console import LogLine
 
 class SelectCommand(BaseCommand):
     subcmd = "select"
-    help = "Select a single Bond to interact with. If the token of this Bond is unlocked, it will be set. (The easiest way to unlock a token is with a power cycle)"
+    help = """Select a single Bond to interact with,
+              If the token of this Bond is unlocked, it will be set.
+              (The easiest way to unlock a token is with a power cycle)"""
     arguments = {
         "bond_id": {
             "nargs": "?",
-            "help": "Bond ID to interact with in subsequent commands",
+            "help": """Bond ID to interact with in subsequent commands
+                       (you can also use a prefix, if it uniquely identifies an
+                       already-discovered Bond""",
         },
-        "--none": {"action": "store_true", "help": "clear selection"},
+        "--clear": {"action": "store_true", "help": "clear selection"},
         "--ip": {"help": "specify Bond IP address"},
         "--port": {"help": "specify Bond HTTP port"},
     }
 
     def run(self, args):
         if args.bond_id:
-            BondDatabase.set("selected_bondid", args.bond_id)
+            matches = [
+                bond
+                for bond in BondDatabase.get_bonds()
+                if bond.startswith(args.bond_id)
+            ]
+            if len(matches) == 0:
+                proceed = input(
+                    "%s hasn't been discovered by bond-cli ('bond discover'). Proceed with setting it? It may not be reachable. y/N"
+                    % args.bond_id
+                )
+                if proceed.lower() == "y":
+                    bond_id = args.bond_id
+                else:
+                    print(
+                        "Aborting. Try 'bond discover' on the same network as your Bond"
+                    )
+                    exit(1)
+            if len(matches) == 1:
+                bond_id = matches[0]
+            if len(matches) > 1:
+                print("Found multiple possibilities:")
+                for match in matches:
+                    print(match)
+                exit(1)
+            BondDatabase.set("selected_bondid", bond_id)
             if args.ip:
-                BondDatabase.set_bond(args.BONDID, "ip", args.ip)
-                LogLine("Set %s IP %s" % (args.BONDID, args.ip))
+                BondDatabase.set_bond(bond_id, "ip", args.ip)
+                print("Set %s IP %s" % (bond_id, args.ip))
             if args.port:
-                BondDatabase.set_bond(args.BONDID, "port", args.port)
-                LogLine("Set %s port %s" % (args.BONDID, args.ip))
+                BondDatabase.set_bond(bond_id, "port", args.port)
+                print("Set %s port %s" % (bond_id, args.ip))
+            print("Selected Bond: %s" % BondDatabase().get("selected_bondid"))
             check_unlocked_token()
-        if args.none:
-            BondDatabase.set("selected_bondid", None)
-        LogLine("Selected Bond: %s" % BondDatabase.get("selected_bondid"))
+        elif args.clear:
+            BondDatabase.pop("selected_bondid", None)
+            print("Cleared selected Bond")
 
 
 def register():

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -10,7 +10,7 @@ def update_token(token, bond_id=None):
     if bond_id not in bonds.keys():
         bonds[bond_id] = dict()
     bonds[bond_id]["token"] = token
-    print("Updated token for %s" % bondid)
+    print("Updated token for %s" % bond_id)
     BondDatabase.set("bonds", bonds)
 
 

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -1,25 +1,43 @@
 from .base_command import BaseCommand
 from bond.database import BondDatabase
 from bond.cli.console import LogLine
+import bond.proto
 
 
-def update_token(token):
-    bondid = BondDatabase.get_assert_selected_bondid()
+def update_token(token, bond_id=None):
+    bond_id = bond_id or BondDatabase.get_assert_selected_bondid()
     bonds = BondDatabase.get_bonds()
-    if bondid not in bonds.keys():
-        bonds[bondid] = dict()
-    bonds[bondid]["token"] = token
-    print(f"Updated token for {bondid}")
+    if bond_id not in bonds.keys():
+        bonds[bond_id] = dict()
+    bonds[bond_id]["token"] = token
+    print(f"Updated token for {bond_id}")
     BondDatabase.set("bonds", bonds)
+
+
+def check_unlocked_token(bond_id=None):
+    bond_id = bond_id or BondDatabase.get_assert_selected_bondid()
+    rsp = bond.proto.get(bond_id, topic="token")
+    token = rsp.get("b", {}).get("token")
+    if token:
+        print("%s's token is unlocked, updating..." % bond_id)
+        update_token(token, bond_id)
+    else:
+        print("%s's token is not unlocked." % bond_id)
+        print("Set it manually with 'bond token <token>',")
+        print("or unlock the token and run 'bond token'")
+        print("(tip: the token is unlocked for a short period after a reboot)")
 
 
 class TokenCommand(BaseCommand):
     subcmd = "token"
     help = "Manage token-based authentication."
-    arguments = {"TOKEN": {"help": "Save Bond token to local database"}}
+    arguments = {"token": {"help": "Save Bond token to local database", "nargs": "?"}}
 
     def run(self, args):
-        update_token(args["Token"])
+        if args.token:
+            update_token(args.token)
+        else:
+            check_unlocked_token()
 
 
 def register():

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -23,8 +23,13 @@ def check_unlocked_token(bond_id=None):
         update_token(token, bond_id)
     else:
         print("%s's token is not unlocked." % bond_id)
-        print("Set it manually with 'bond token <token>',")
-        print("or unlock the token and run 'bond token'")
+        stored_token = BondDatabase.get_bond(bond_id).get('token')
+        if stored_token:
+            print("There's already one token in your local database: %s." % stored_token)
+            print("If this token is obsolete, you will need to set the new token.")
+        print(
+            "You can set it manually with 'bond token <token>', or unlock the token and run 'bond token'"
+        )
         print("(tip: the token is unlocked for a short period after a reboot)")
 
 
@@ -38,6 +43,7 @@ class TokenCommand(BaseCommand):
             update_token(args.token)
         else:
             check_unlocked_token()
+
 
 def register():
     TokenCommand()

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -18,6 +18,7 @@ def get_branch(args, target):
     else:
         return args.branch.replace("/", "-")
 
+
 def get_latest_version(target, branch):
     url = f"https://s3.amazonaws.com/bond-updates/v2/{target}/{branch}/versions_internal.json"
     rsp = requests.get(url)

--- a/bond/database/database.py
+++ b/bond/database/database.py
@@ -46,6 +46,7 @@ class BondDatabase(MutableMapping):
     def __delitem__(self, key):
         with self.lock:
             del self.db[key]
+            self.__save()
 
     def __iter__(self):
         return self.db.__iter__()
@@ -57,7 +58,7 @@ class BondDatabase(MutableMapping):
 
     @staticmethod
     def get_assert_selected_bondid():
-        selected_bondid = BondDatabase.get("selected_bondid")
+        selected_bondid = BondDatabase().get("selected_bondid")
         if selected_bondid is None:
             raise Exception("No Bond selected. Use 'bond select' first.")
         return selected_bondid
@@ -68,7 +69,7 @@ class BondDatabase(MutableMapping):
 
     @staticmethod
     def get_bond(bondid):
-        return BondDatabase().get(bondid, dict())
+        return BondDatabase().get_bonds().get(bondid, dict())
 
     @staticmethod
     def set_bond(bondid, key, value):
@@ -76,11 +77,7 @@ class BondDatabase(MutableMapping):
         bonds.setdefault(bondid, dict())
         bonds[bondid][key] = value
         BondDatabase.set("bonds", bonds)
-
-    @staticmethod
-    def get(key):
-        return BondDatabase()[key]
-
+    
     @staticmethod
     def set(key, value):
         BondDatabase()[key] = value

--- a/bond/database/test_database.py
+++ b/bond/database/test_database.py
@@ -3,4 +3,4 @@ from bond.database import BondDatabase
 def test_database_get_and_set():
   for i in range(5):
     BondDatabase.set("test", i)
-    assert BondDatabase.get("test") == i
+    assert BondDatabase().get("test") == i

--- a/bond/proto/http.py
+++ b/bond/proto/http.py
@@ -47,4 +47,7 @@ class HTTP_Transport(BaseTransport):
             body = json.loads(rsp.text)
         except:
             body = None
+        if rsp.status_code == 401:
+            print("Invalid token! Have you set it with 'bond token' yet?")
+            exit(1)
         return {"s": rsp.status_code, "b": body, "bondid": self.bondid}

--- a/bond/proto/wye.py
+++ b/bond/proto/wye.py
@@ -3,7 +3,7 @@ from bond.proto.http import HTTP_Transport
 
 
 def get_bonds():
-    selected_bondid = BondDatabase.get("selected_bondid")
+    selected_bondid = BondDatabase().get("selected_bondid")
     if not selected_bondid:
         return BondDatabase.get_bonds().keys()
     else:


### PR DESCRIPTION
`bond select <id>` Selects the Bond, and if it's reachable and has an unlocked token, it sets it and prints it out. You can also "fuzzy select" a bond by ID. That is, if you only have one Bond with prefix "Z", `bond select Z` is sufficient.

`bond token` without providing a token does the same check as select, but prints out instructions for unlocking the token if it's locked, or manually setting the token.

If the token's ever wrong (that is, a 401), the program will print that out and exit.