### PR TITLE
Version, Devices: interact only with selected Bond

### DIFF
--- a/bond/commands/devices.py
+++ b/bond/commands/devices.py
@@ -5,18 +5,27 @@ from bond.cli.table import Table
 from bond.database import BondDatabase
 import bond.proto
 
+
 class DevicesCommand(BaseCommand):
     subcmd = "devices"
     help = "Interact with the selected Bond's devices."
 
     def run(self, args):
+        bond_id = BondDatabase.get_assert_selected_bondid()
+        print("Devices on %s" % bond_id)
         with Table(["dev_id", "name", "location"]) as table:
-            bond_id = BondDatabase.get_assert_selected_bondid()
             dev_ids = bond.proto.get(bond_id, topic="devices").get("b", {})
-            dev_ids.pop('_', None)
+            dev_ids.pop("_", None)
             for dev_id in dev_ids:
                 dev = bond.proto.get(bond_id, topic="devices/%s" % dev_id).get("b", {})
-                table.add_row({"dev_id": dev_id, "name": dev.get("name"), "location": dev.get("location")})
+                table.add_row(
+                    {
+                        "dev_id": dev_id,
+                        "name": dev.get("name"),
+                        "location": dev.get("location"),
+                    }
+                )
+
 
 def register():
     DevicesCommand()

--- a/bond/commands/devices.py
+++ b/bond/commands/devices.py
@@ -1,56 +1,22 @@
+import time
+
 from .base_command import BaseCommand
 from bond.cli.table import Table
-from bond.cli.console import ExceptionLine
-import time
-from bond.proto import get_all_async, get_async
-
+from bond.database import BondDatabase
+import bond.proto
 
 class DevicesCommand(BaseCommand):
     subcmd = "devices"
-    help = "Interact with devices."
+    help = "Interact with the selected Bond's devices."
 
     def run(self, args):
-        with Table(["bondid", "dev_id", "name", "location"]) as table:
-
-            def chain_devices(bondid, rsp):
-                threads = []
-                for dev_id in rsp["b"]:
-                    if dev_id[:1] == "_":
-                        continue
-                    threads.append(
-                        get_async(
-                            bondid,
-                            topic="devices/%s" % dev_id,
-                            on_success=(
-                                lambda dev_id: lambda bondid, rsp: table.add_row(
-                                    {
-                                        "bondid": bondid,
-                                        "dev_id": dev_id,
-                                        "name": rsp["b"]["name"],
-                                        "location": rsp["b"]["location"],
-                                    }
-                                )
-                            )(dev_id),
-                            on_error=(
-                                lambda dev_id: lambda bondid, e: [
-                                    table.add_row({"bondid": bondid, "dev_id": dev_id}),
-                                    ExceptionLine(e),
-                                ]
-                            )(dev_id),
-                        )
-                    )
-                [t.join() for t in threads]
-
-            threads = get_all_async(
-                topic="devices",
-                on_success=chain_devices,
-                on_error=lambda bondid, e: [
-                    table.add_row({"bondid": bondid}),
-                    ExceptionLine(e),
-                ],
-            )
-            [t.join() for t in threads]
-
+        with Table(["dev_id", "name", "location"]) as table:
+            bond_id = BondDatabase.get_assert_selected_bondid()
+            dev_ids = bond.proto.get(bond_id, topic="devices").get("b", {})
+            dev_ids.pop('_', None)
+            for dev_id in dev_ids:
+                dev = bond.proto.get(bond_id, topic="devices/%s" % dev_id).get("b", {})
+                table.add_row({"dev_id": dev_id, "name": dev.get("name"), "location": dev.get("location")})
 
 def register():
     DevicesCommand()

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -59,10 +59,7 @@ class LivelogCommand(BaseCommand):
             "help": "set the verbosity for the given subsys: warn, info, debug, or trace",
             "choices": LEVEL_MAP.keys(),
         },
-        "--out": {
-            "help": "a filename to write the logs to",
-            "default": os.devnull,
-        }
+        "--out": {"help": "a filename to write the logs to", "default": os.devnull},
     }
 
     def run(self, args):

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -18,6 +18,7 @@ def get_branch(args, target):
     else:
         return args.branch.replace("/", "-")
 
+
 def get_latest_version(target, branch):
     url = f"https://s3.amazonaws.com/bond-updates/v2/{target}/{branch}/versions_internal.json"
     rsp = requests.get(url)

--- a/bond/commands/version.py
+++ b/bond/commands/version.py
@@ -1,27 +1,21 @@
 from .base_command import BaseCommand
 from bond.cli.table import Table
 import time
-from bond.proto import get_all_async
+import bond.proto
+from bond.database import BondDatabase
 
 
 class VersionCommand(BaseCommand):
     subcmd = "version"
-    help = "Get firwmare version."
+    help = "Get firmware version and target."
 
     def run(self, args):
-        table = Table(["Bond ID", "Target", "Version"])
-        threads = get_all_async(
-            topic="sys/version",
-            on_success=lambda bondid, rsp: table.add_row(
-                {
-                    "Bond ID": bondid,
-                    "Target": rsp["b"]["target"],
-                    "Version": rsp["b"]["fw_ver"],
-                }
-            ),
-            on_error=lambda bondid, e: table.add_row({"Bond ID": bondid}),
-        )
-        [t.join() for t in threads]
+        bond_id = BondDatabase.get_assert_selected_bondid()
+        rsp = bond.proto.get(bond_id, topic="sys/version")
+        body = rsp.get("b", {})
+        print(bond_id)
+        print("Target: %s" % body.get("target"))
+        print("Version: %s" % body.get("fw_ver"))
 
 
 def register():

--- a/bond/commands/version.py
+++ b/bond/commands/version.py
@@ -7,7 +7,7 @@ from bond.database import BondDatabase
 
 class VersionCommand(BaseCommand):
     subcmd = "version"
-    help = "Get firmware version and target."
+    help = "Get firmware version and target of the selected Bond."
 
     def run(self, args):
         bond_id = BondDatabase.get_assert_selected_bondid()

--- a/bond/database/database.py
+++ b/bond/database/database.py
@@ -59,7 +59,8 @@ class BondDatabase(MutableMapping):
     def get_assert_selected_bondid():
         selected_bondid = BondDatabase.get("selected_bondid")
         if selected_bondid is None:
-            raise Exception("No Bond selected. Use 'bond select' first.")
+            print("No Bond selected. Use 'bond select' first.")
+            exit(1)
         return selected_bondid
 
     @staticmethod


### PR DESCRIPTION
This is a step towards reduced complexity in this project.

`bond version` simply asks the selected Bond for its version, not all Bonds in the database. `bond devices` now has similar behavior as well.

The next step I have in mind is selecting a device on the selected Bond — `bond devices select <dev_id>` — then you can execute actions on the device with `bond device action TurnOn` etc. This will require a change in the way subparsers are added, as some subparsers will need their own subparsers.