### PR TITLE
Tweak the timing of the devices error message

### DIFF
--- a/bond/commands/devices.py
+++ b/bond/commands/devices.py
@@ -12,9 +12,9 @@ class DevicesCommand(BaseCommand):
 
     def run(self, args):
         bond_id = BondDatabase.get_assert_selected_bondid()
+        dev_ids = bond.proto.get(bond_id, topic="devices").get("b", {})
         print("Devices on %s" % bond_id)
         with Table(["dev_id", "name", "location"]) as table:
-            dev_ids = bond.proto.get(bond_id, topic="devices").get("b", {})
             dev_ids.pop("_", None)
             for dev_id in dev_ids:
                 dev = bond.proto.get(bond_id, topic="devices/%s" % dev_id).get("b", {})


### PR DESCRIPTION
When `bond devices` fails due to an invalid token (or the lack of a token), the current message is as follows

```bash
$ bond devices
Devices on ZZCC66330
----------------------------------------------------
|dev_id          |name            |location        |
|----------------|----------------|----------------|
Invalid token! Have you set it with 'bond token' yet?
----------------------------------------------------

```

This tweak makes it just
```bash
$ bond devices
Invalid token! Have you set it with 'bond token' yet?
```