### PR TITLE
Livelog and Discover: Catch keyboard interrupts

### DIFF
--- a/bond/commands/discover.py
+++ b/bond/commands/discover.py
@@ -11,7 +11,10 @@ class DiscoverCommand(BaseCommand):
     def run(self, args):
         table = Table(["bondid", "ip", "port"])
         scanner = Scanner(table.add_row)
-        time.sleep(5)
+        try:
+            time.sleep(5)
+        except KeyboardInterrupt:
+            pass
 
 
 def register():

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -84,7 +84,12 @@ class LivelogCommand(BaseCommand):
         with open(args.out, "w+") as log:
             log.write("\n===== %s =====\n" % datetime.datetime.now())
             while True:
-                data, addr = sock.recvfrom(1024 * 16)
+                try:
+                    data, addr = sock.recvfrom(1024 * 16)
+                except KeyboardInterrupt:
+                    if args.out != '/dev/null':
+                        print("Logs written to %s", args.out)
+                    break
                 logline = data.decode("utf-8")
                 sys.stdout.write(logline)
                 log.write(logline)


### PR DESCRIPTION
So as not to print a long traceback when exiting these. Discover you might let run the full 5 seconds, but I usually cancel it when I've seen what I expect to see.