### PR TITLE
Improve exception handling

### DIFF
--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -36,10 +36,9 @@ class SelectCommand(BaseCommand):
                 if proceed.lower() == "y":
                     bond_id = args.bond_id
                 else:
-                    print(
+                    raise SystemExit(
                         "Aborting. Try 'bond discover' on the same network as your Bond"
                     )
-                    exit(1)
             if len(matches) == 1:
                 bond_id = matches[0]
             if len(matches) > 1:

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -24,8 +24,7 @@ def get_latest_version(target, branch):
     url = f"https://s3.amazonaws.com/bond-updates/v2/{target}/{branch}/versions_internal.json"
     rsp = requests.get(url)
     if rsp.status_code != 200:
-        print("Failed to find an upgrade for target %s on branch %s" % (target, branch))
-        exit(1)
+        raise SystemExit("Failed to find an upgrade for target %s on branch %s" % (target, branch))
     return json.loads(rsp.content)["versions"][0]
 
 
@@ -110,11 +109,9 @@ class UpgradeCommand(BaseCommand):
                     "Are you sure you know EXACTLY what you're doing? [N/yessir] "
                 )
                 if response != "yessir":
-                    print("Yeah, best not to override the target anyways.")
-                    exit(1)
+                    raise SystemExit("Yeah, best not to override the target anyways.")
                 if input("Have your fire extinguisher ready? [N/y]").lower() != "y":
-                    print("Well, go find one!")
-                    exit(1)
+                    raise SystemExit("Well, go find one!")
                 target = args.target
                 print("Target manually overriden.")
 
@@ -127,7 +124,6 @@ class UpgradeCommand(BaseCommand):
         if new_ver == current_ver:
             print("WARNING: Versions are identical.")
         if input("Are you sure? [N/y] ").lower() != "y":
-            print("Pfew. That was close. Aborting!")
-            exit(1)
+            raise SystemExit("Pfew. That was close. Aborting!")
         print("Requesting upgrade...")
         do_upgrade(bondid, version_obj)

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -24,7 +24,9 @@ def get_latest_version(target, branch):
     url = f"https://s3.amazonaws.com/bond-updates/v2/{target}/{branch}/versions_internal.json"
     rsp = requests.get(url)
     if rsp.status_code != 200:
-        raise SystemExit("Failed to find an upgrade for target %s on branch %s" % (target, branch))
+        raise SystemExit(
+            "Failed to find an upgrade for target %s on branch %s" % (target, branch)
+        )
     return json.loads(rsp.content)["versions"][0]
 
 

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -44,7 +44,7 @@ def do_upgrade(bondid, version_obj):
         time.sleep(1)
         try:
             rsp = bond.proto.get(bondid, topic="sys/upgrade")
-        except requests.exceptions.ReadTimeout:
+        except requests.RequestException:
             sys.stdout.write(".")
             sys.stdout.flush()
             continue
@@ -66,7 +66,7 @@ def do_upgrade(bondid, version_obj):
         # check for in progress return get on upgrade
         try:
             rsp = bond.proto.get(bondid, topic="sys/version", timeout=2)
-        except requests.exceptions.ConnectTimeout:
+        except requests.RequestException:
             sys.stdout.write(".")
             sys.stdout.flush()
             continue

--- a/bond/database/database.py
+++ b/bond/database/database.py
@@ -77,7 +77,7 @@ class BondDatabase(MutableMapping):
         bonds.setdefault(bondid, dict())
         bonds[bondid][key] = value
         BondDatabase.set("bonds", bonds)
-    
+
     @staticmethod
     def set(key, value):
         BondDatabase()[key] = value

--- a/bond/database/database.py
+++ b/bond/database/database.py
@@ -60,8 +60,7 @@ class BondDatabase(MutableMapping):
     def get_assert_selected_bondid():
         selected_bondid = BondDatabase().get("selected_bondid")
         if selected_bondid is None:
-            print("No Bond selected. Use 'bond select' first.")
-            exit(1)
+            raise SystemExit("No Bond selected. Use 'bond select' first.")
         return selected_bondid
 
     @staticmethod

--- a/bond/database/test_database.py
+++ b/bond/database/test_database.py
@@ -1,6 +1,7 @@
 from bond.database import BondDatabase
 
+
 def test_database_get_and_set():
-  for i in range(5):
-    BondDatabase.set("test", i)
-    assert BondDatabase().get("test") == i
+    for i in range(5):
+        BondDatabase.set("test", i)
+        assert BondDatabase().get("test") == i

--- a/bond/proto/http.py
+++ b/bond/proto/http.py
@@ -48,6 +48,5 @@ class HTTP_Transport(BaseTransport):
         except:
             body = None
         if rsp.status_code == 401:
-            print("Invalid token! Have you set it with 'bond token' yet?")
-            exit(1)
+            raise SystemExit("Invalid token! Have you set it with 'bond token' yet?")
         return {"s": rsp.status_code, "b": body, "bondid": self.bondid}

--- a/setup.py
+++ b/setup.py
@@ -1,21 +1,21 @@
 from setuptools import setup, find_packages
 
-DEPS_ALL = open('requirements.txt').readlines()
+DEPS_ALL = open("requirements.txt").readlines()
 
-DEPS_TEST = DEPS_ALL + open('requirements-test.txt').readlines()
+DEPS_TEST = DEPS_ALL + open("requirements-test.txt").readlines()
 
 setup(
-    name='bond-cli',
-    version='0.0.8',
-    author='Olibra',
+    name="bond-cli",
+    version="0.0.8",
+    author="Olibra",
     packages=find_packages(),
-    scripts=['bond/bond'],
+    scripts=["bond/bond"],
     include_package_data=True,
-    description='Bond CLI',
-    long_description=open('README.md').read(),
+    description="Bond CLI",
+    long_description=open("README.md").read(),
     long_description_content_type="text/markdown",
-    python_requires='>=3.6',
-    setup_requires=['pytest-runner'],
+    python_requires=">=3.6",
+    setup_requires=["pytest-runner"],
     install_requires=DEPS_ALL,
-    tests_require=DEPS_TEST
+    tests_require=DEPS_TEST,
 )


### PR DESCRIPTION
I had the upgrade working so that the first stage (waiting on initial download) was only catching ReadTimeout, the second stage (waiting on reboot) was only catching ConnectTimeout. I've been messing around with this tool a lot today, and it seems both are possible in both stages, so I've gone with their parent class, RequestException.

Also converted a lot of print + exit(1)s to SystemExit, as it seems that is more Pythonic.