### PR TITLE
Fix Select and List pops

### DIFF
--- a/bond/commands/list.py
+++ b/bond/commands/list.py
@@ -10,7 +10,7 @@ class ListCommand(BaseCommand):
 
     def run(self, args):
         if args.clear:
-            BondDatabase.pop("bonds", None)
+            BondDatabase().pop("bonds", None)
             print("Cleared discovered Bonds")
         else:
             table = Table(["bondid", "ip", "token"])

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -57,7 +57,7 @@ class SelectCommand(BaseCommand):
             print("Selected Bond: %s" % BondDatabase().get("selected_bondid"))
             token = check_unlocked_token()
         elif args.clear:
-            BondDatabase.pop("selected_bondid", None)
+            BondDatabase().pop("selected_bondid", None)
             print("Cleared selected Bond")
 
 


### PR DESCRIPTION
Select and List were using a non-existent static method `pop` of `BondDatabase`, when really they should be using an instance method of its singleton instance.

It's not possible to define a static method with the same name as an instance method, so we'll just get the instance before `pop`ping