### PR TITLE
commands: add WiFiShutdown

### DIFF
--- a/bond/commands/wifi.py
+++ b/bond/commands/wifi.py
@@ -28,6 +28,23 @@ class WifiCommand(BaseCommand):
         if rsp["s"] > 299:
             print("HTTP %d %s" % (rsp["s"], rsp["b"]["_error_msg"]))
 
+class WifiShutdownCommand(BaseCommand):
+    subcmd = "wifi_shutdown"
+    help = "Shutdown WiFi until reboot (requires fw >= v2.11.4)"
+    arguments = {}
+
+    def run(self, args):
+        bondid = BondDatabase.get_assert_selected_bondid()
+        rsp = bond.proto.patch(
+            bondid,
+            topic="debug/wifi",
+            body={ "shutdown": 1 },
+        )
+        if rsp["s"] > 299:
+            print("HTTP %d %s" % (rsp["s"], rsp["b"]["_error_msg"]))
+
+
 
 def register():
     WifiCommand()
+    WifiShutdownCommand()

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEPS_TEST = DEPS_ALL + open("requirements-test.txt").readlines()
 
 setup(
     name="bond-cli",
-    version="0.0.9",
+    version="0.0.10",
     author="Olibra",
     packages=find_packages(),
     scripts=["bond/bond"],


### PR DESCRIPTION
```
bond wifi_shutdown
```

Will cause Bond to shutdown the WiFi radio after 2 seconds, and remain off until reboot (or power cycle).

This is useful for hardware debugging.