### PR TITLE
Add tag push trigger for release workflow

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -6,6 +6,9 @@ name: Upload Python Package
 on:
   release:
     types: [created]
+  push:
+    branches: [trunk]
+    tags: ["v*"]
 
 jobs:
   deploy:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEPS_TEST = DEPS_ALL + open("requirements-test.txt").readlines()
 
 setup(
     name="bond-cli",
-    version="0.0.8",
+    version="0.0.9",
     author="Olibra",
     packages=find_packages(),
     scripts=["bond/bond"],


### PR DESCRIPTION
Title says it all

EDIT: tested, it works. You can now just push a tag to deploy.