### PR TITLE
Add Livelog delete command

### DIFF
--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -12,8 +12,12 @@ import os
 LEVEL_MAP = {"warn": 2, "info": 3, "debug": 4, "trace": 5}
 
 
-def do_livelog(bondid, ip, port):
+def stop_livelog(bondid):
     bond.proto.delete(bondid, topic="debug/livelog")
+
+
+def do_livelog(bondid, ip, port):
+    stop_livelog(bondid)
     time.sleep(0.5)
     bond.proto.put(bondid, topic="debug/livelog", body={"ip": ip, "port": port})
 
@@ -60,11 +64,19 @@ class LivelogCommand(BaseCommand):
             "choices": LEVEL_MAP.keys(),
         },
         "--out": {"help": "a filename to write the logs to", "default": os.devnull},
+        "--delete": { # TODO: refactor to subcommand when possible
+            "help": "stop the bond from logging, improving performance",
+            "action": "store_true",
+        },
     }
 
     def run(self, args):
         bondid = BondDatabase.get_assert_selected_bondid()
 
+        if args.delete:
+            bondid = BondDatabase.get_assert_selected_bondid()
+            stop_livelog(bondid)
+            print("Livelog stopped for %s" % bondid)
         if args.level:
             bond.proto.patch(
                 bondid, topic="debug/syslog", body={"lvl": LEVEL_MAP[args.level]}
@@ -87,7 +99,7 @@ class LivelogCommand(BaseCommand):
                 try:
                     data, addr = sock.recvfrom(1024 * 16)
                 except KeyboardInterrupt:
-                    if args.out != '/dev/null':
+                    if args.out != "/dev/null":
                         print("Logs written to %s", args.out)
                     break
                 logline = data.decode("utf-8")

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -8,6 +8,7 @@ import random
 import time
 import sys
 import os
+from requests.exceptions import RequestException
 
 LEVEL_MAP = {"warn": 2, "info": 3, "debug": 4, "trace": 5}
 
@@ -101,6 +102,10 @@ class LivelogCommand(BaseCommand):
                 try:
                     data, addr = sock.recvfrom(1024 * 16)
                 except KeyboardInterrupt:
+                    try:
+                        stop_livelog()
+                    except RequestException:
+                        pass
                     if args.out != "/dev/null":
                         print("Logs written to %s", args.out)
                     break

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -14,7 +14,6 @@ LEVEL_MAP = {"warn": 2, "info": 3, "debug": 4, "trace": 5}
 
 def stop_livelog(bondid):
     bond.proto.delete(bondid, topic="debug/livelog")
-    bond.proto.delete(bondid, topic="debug/syslog")
 
 
 def do_livelog(bondid, ip, port):
@@ -77,6 +76,7 @@ class LivelogCommand(BaseCommand):
         if args.delete:
             bondid = BondDatabase.get_assert_selected_bondid()
             stop_livelog(bondid)
+            bond.proto.delete(bondid, topic="debug/syslog")
             print("Livelog stopped for %s" % bondid)
         if args.level:
             bond.proto.patch(

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -14,6 +14,7 @@ LEVEL_MAP = {"warn": 2, "info": 3, "debug": 4, "trace": 5}
 
 def stop_livelog(bondid):
     bond.proto.delete(bondid, topic="debug/livelog")
+    bond.proto.delete(bondid, topic="debug/syslog")
 
 
 def do_livelog(bondid, ip, port):
@@ -65,7 +66,7 @@ class LivelogCommand(BaseCommand):
         },
         "--out": {"help": "a filename to write the logs to", "default": os.devnull},
         "--delete": { # TODO: refactor to subcommand when possible
-            "help": "stop the bond from logging, improving performance",
+            "help": "stop the bond from logging, and restores its default verbosity, improving performance",
             "action": "store_true",
         },
     }

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -78,6 +78,7 @@ class LivelogCommand(BaseCommand):
             stop_livelog(bondid)
             bond.proto.delete(bondid, topic="debug/syslog")
             print("Livelog stopped for %s" % bondid)
+            return
         if args.level:
             bond.proto.patch(
                 bondid, topic="debug/syslog", body={"lvl": LEVEL_MAP[args.level]}

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEPS_TEST = DEPS_ALL + open("requirements-test.txt").readlines()
 
 setup(
     name="bond-cli",
-    version="0.0.8",
+    version="0.0.9",
     author="Olibra",
     packages=find_packages(),
     scripts=["bond/bond"],

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEPS_TEST = DEPS_ALL + open("requirements-test.txt").readlines()
 
 setup(
     name="bond-cli",
-    version="0.0.10",
+    version="0.0.11",
     author="Olibra",
     packages=find_packages(),
     scripts=["bond/bond"],


### PR DESCRIPTION
Remembered that livelog and high-verbosity syslog can cause a major performance hit, so I added an option to kill an ongoing livelog.

This has been a problem especially when debugging signal generation, as there're noisy logs there.

More convenient than a reboot or `bond livelog --level warn` + kill

Even better would be to catch a kill signal and tear this down before exit. EDIT: < added this! Ctrl-C will attempt to end the livelog session and restore syslog verbosity to the default