### PR TITLE
Enable downgrading to an older FW version

### DIFF
--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -21,7 +21,7 @@ def get_branch_string(branch, target):
 
 
 def get_s3_version(target, branch, depth=0):
-    url = f"https://s3.amazonaws.com/bond-updates/v2/{target}/{branch}/versions_internal.json"
+    url = f"https://bond-updates.s3.amazonaws.com/v2/{target}/{branch}/versions_internal.json"
     rsp = requests.get(url)
     if rsp.status_code != 200:
         raise SystemExit(

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -20,14 +20,15 @@ def get_branch_string(branch, target):
         return branch.replace("/", "-")
 
 
-def get_latest_version(target, branch):
+def get_s3_version(target, branch, depth=0):
     url = f"https://s3.amazonaws.com/bond-updates/v2/{target}/{branch}/versions_internal.json"
     rsp = requests.get(url)
     if rsp.status_code != 200:
         raise SystemExit(
             "Failed to find an upgrade for target %s on branch %s" % (target, branch)
         )
-    return json.loads(rsp.content)["versions"][0]
+    index = depth or 0
+    return json.loads(rsp.content)["versions"][index]
 
 
 def do_upgrade(bondid, version_obj):
@@ -91,6 +92,9 @@ class UpgradeCommand(BaseCommand):
         "--target": {
             "help": "override detected target. Useful in development, but may cause irreversible device malfunction!"
         },
+        "--rollback": {
+            "help": "number of versions to roll back. 0 is the current version, 1 is the one before that and so on."
+        }
     }
 
     def run(self, args):
@@ -120,7 +124,8 @@ class UpgradeCommand(BaseCommand):
         branch = get_branch_string(args.branch, target)
         print(f"Selected Branch: \t{branch}")
         print(f"Current Version: \t{current_ver}")
-        version_obj = get_latest_version(target, branch)
+        rollback = int(args.rollback) or 0
+        version_obj = get_s3_version(target, branch, rollback)
         new_ver = version_obj["version"]
         print(f"Installing Version: \t{new_ver}")
         if new_ver == current_ver:

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -21,7 +21,7 @@ def get_branch_string(branch, target):
 
 
 def get_s3_version(target, branch, depth=0):
-    url = f"https://bond-updates.s3.amazonaws.com/v2/{target}/{branch}/versions_internal.json"
+    url = f"https://s3.amazonaws.com/bond-updates/v2/{target}/{branch}/versions_internal.json"
     rsp = requests.get(url)
     if rsp.status_code != 200:
         raise SystemExit(
@@ -91,7 +91,7 @@ class UpgradeCommand(BaseCommand):
         "--target": {
             "help": "override detected target. Useful in development, but may cause irreversible device malfunction!"
         },
-        "--release-num": {
+        "--age": {
             "help": "number of releases to go back to. 0 is the latest version, 1 is the one before that and so on.",
             "type": int,
             "default": 0
@@ -125,7 +125,7 @@ class UpgradeCommand(BaseCommand):
         branch = get_branch_string(args.branch, target)
         print(f"Selected Branch: \t{branch}")
         print(f"Current Version: \t{current_ver}")
-        version_obj = get_s3_version(target, branch, args.release_num)
+        version_obj = get_s3_version(target, branch, args.age)
         new_ver = version_obj["version"]
         print(f"Installing Version: \t{new_ver}")
         if new_ver == current_ver:

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -27,8 +27,7 @@ def get_s3_version(target, branch, depth=0):
         raise SystemExit(
             "Failed to find an upgrade for target %s on branch %s" % (target, branch)
         )
-    index = depth or 0
-    return json.loads(rsp.content)["versions"][index]
+    return json.loads(rsp.content)["versions"][depth]
 
 
 def do_upgrade(bondid, version_obj):
@@ -92,8 +91,10 @@ class UpgradeCommand(BaseCommand):
         "--target": {
             "help": "override detected target. Useful in development, but may cause irreversible device malfunction!"
         },
-        "--rollback": {
-            "help": "number of versions to roll back. 0 is the current version, 1 is the one before that and so on."
+        "--release-num": {
+            "help": "number of releases to go back to. 0 is the latest version, 1 is the one before that and so on.",
+            "type": int,
+            "default": 0
         }
     }
 
@@ -124,8 +125,7 @@ class UpgradeCommand(BaseCommand):
         branch = get_branch_string(args.branch, target)
         print(f"Selected Branch: \t{branch}")
         print(f"Current Version: \t{current_ver}")
-        rollback = int(args.rollback) or 0
-        version_obj = get_s3_version(target, branch, rollback)
+        version_obj = get_s3_version(target, branch, args.release_num)
         new_ver = version_obj["version"]
         print(f"Installing Version: \t{new_ver}")
         if new_ver == current_ver:


### PR DESCRIPTION
I wanted to test FW upgrade to the latest version but I already was at it.
So I added a `--rollback` argument to `upgrade`.
If I use `--rollback 1` it will upgrade to the version with index 1 on the versions.json file. Defaults to `0` for the latest version