### PR TITLE
Increase mdns discovery timeout to 10 seconds

### DIFF
--- a/bond/commands/discover.py
+++ b/bond/commands/discover.py
@@ -14,7 +14,7 @@ class DiscoverCommand(BaseCommand):
         table = Table(["bondid", "ip", "port"])
         scanner = Scanner(table.add_row)    # noqa: F841
         try:
-            time.sleep(5)
+            time.sleep(10)
         except KeyboardInterrupt:
             pass
 


### PR DESCRIPTION
Some devices take even longer than 10 seconds to respond which
risks their records being removed because of
Passive Observation Of Failures (rfc6762 section 10.5)

`python-zeroconf` doesn't currently implement POOF, but
it may be added in the near future (https://github.com/jstasiak/python-zeroconf/issues/900) which could make bond devices difficult
to discover for Home Assistant users.

mDNSResponder on apple devices is likely already unexpectedly evicting
records for slow responders.