### PR TITLE
[1] Marcio/Make a few params option on device create

### DIFF
--- a/bond/commands/device_create.py
+++ b/bond/commands/device_create.py
@@ -11,34 +11,40 @@ class DeviceCreateCommand(BaseCommand):
     arguments = {
         "--name": {"help": "device name", "required": True},
         "--template": {"help": "template name (RCF84, A1, etc.)", "required": True},
-        "--addr": {"help": "device address (binary)", "required": True},
-        "--freq": {"help": "signal frequency (kHz)", "type": int, "required": True},
+        "--location": {"help": "location name (Bedroom, Living Room, etc.)", "required": True},
+        "--addr": {"help": "device address (binary)", "required": False},
+        "--freq": {"help": "signal frequency (kHz)", "type": int, "required": False},
         "--bps": {
             "help": "signal data rate (bits per second)",
             "type": int,
-            "required": True,
+            "required": False,
         },
         "--zero_gap": {
             "help": "inter-packet space duration (milliseconds)",
             "type": int,
-            "required": True,
+            "required": False,
         },
     }
 
     def run(self, args):
         bondid = BondDatabase.get_assert_selected_bondid()
+        properties = {}
+        if args.addr:
+            properties["addr"] = args.addr
+        if args.freq:
+            properties["freq"] = args.freq
+        if args.bps:
+            properties["bps"] = args.bps
+        if args.zero_gap:
+            properties["zero_gap"] = args.zero_gap
         rsp = bond.proto.post(
             bondid,
             topic="devices",
             body={
                 "name": args.name,
+                "location": args.location,
                 "template": args.template,
-                "properties": {
-                    "addr": args.addr,
-                    "freq": args.freq,
-                    "bps": args.bps,
-                    "zero_gap": args.zero_gap,
-                },
+                "properties": properties,
             },
         )
         if rsp["s"] > 299:


### PR DESCRIPTION
`addr`, `freq`, `bps` and `zero_gap` should not be required. This PR removes their requirement.
Also it adds `location` as required 