### PR TITLE
New commands and improvements

### DIFF
--- a/bond/app.py
+++ b/bond/app.py
@@ -13,6 +13,7 @@ COMMANDS = [
     "devices_clear",
     "groups",
     "group_create",
+    "groups_clear",
     "livelog",
     "signal",
     "reset",

--- a/bond/app.py
+++ b/bond/app.py
@@ -10,6 +10,7 @@ COMMANDS = [
     "list",
     "devices",
     "device_create",
+    "devices_clear",
     "groups",
     "group_create",
     "livelog",

--- a/bond/app.py
+++ b/bond/app.py
@@ -10,6 +10,7 @@ COMMANDS = [
     "list",
     "devices",
     "device_create",
+    "groups",
     "livelog",
     "signal",
     "reset",

--- a/bond/app.py
+++ b/bond/app.py
@@ -11,6 +11,7 @@ COMMANDS = [
     "devices",
     "device_create",
     "groups",
+    "group_create",
     "livelog",
     "signal",
     "reset",

--- a/bond/cli/__init__.py
+++ b/bond/cli/__init__.py
@@ -1,1 +1,1 @@
-from .main import load_commands, register, execute_from_command_line  # noqa: F401
+from bond.cli.main import load_commands, register, execute_from_command_line  # noqa: F401

--- a/bond/cli/__init__.py
+++ b/bond/cli/__init__.py
@@ -1,1 +1,5 @@
-from bond.cli.main import load_commands, register, execute_from_command_line  # noqa: F401
+from bond.cli.main import (
+    load_commands,
+    register,
+    execute_from_command_line,
+)  # noqa: F401

--- a/bond/cli/__init__.py
+++ b/bond/cli/__init__.py
@@ -1,5 +1,1 @@
-from bond.cli.main import (
-    load_commands,
-    register,
-    execute_from_command_line,
-)  # noqa: F401
+from bond.cli.main import load_commands, register, execute_from_command_line  # noqa: F401

--- a/bond/cli/main.py
+++ b/bond/cli/main.py
@@ -1,6 +1,7 @@
 import argparse
 import importlib
-from .console import console_terminate   # noqa: F401
+
+from bond.cli.console import console_terminate  # noqa: F401
 
 _parser = argparse.ArgumentParser(prog="bond")
 _subparsers = _parser.add_subparsers(dest="subparser_name")

--- a/bond/cli/table.py
+++ b/bond/cli/table.py
@@ -1,4 +1,4 @@
-from .console import lock
+from bond.cli.console import lock
 
 
 class Table(object):

--- a/bond/cli/table.py
+++ b/bond/cli/table.py
@@ -2,7 +2,7 @@ from bond.cli.console import lock
 
 
 class Table(object):
-    col_width = 16
+    col_width = 20
 
     def __init__(self, header, quiet=False):
         lock.acquire()

--- a/bond/cli/table.py
+++ b/bond/cli/table.py
@@ -4,25 +4,33 @@ from bond.cli.console import lock
 class Table(object):
     col_width = 16
 
-    def __init__(self, header):
+    def __init__(self, header, quiet=False):
         lock.acquire()
         self.open = True
         self.header = header
+        self.quiet = quiet
         self.print_header()
 
     def print_tabbed(self, lst):
-        print("|", end="")
+        separator = "" if self.quiet else "|"
+
+        print("", end=separator)
+
         for item in lst:
-            print(("%-" + str(self.col_width) + "s|") % str(item), end="")
+            print(f"{str(item):<{self.col_width}}", end=separator)
+
         print()
 
-    def print_boarder(self):
-        print("-" + "-" * ((self.col_width + 1) * len(self.header) - 1) + "-")
+    def print_border(self):
+        if not self.quiet:
+            print("-" * ((self.col_width + 1) * len(self.header) + 1))
 
     def print_header(self):
-        self.print_boarder()
+        self.print_border()
         self.print_tabbed(self.header)
-        self.print_tabbed([("-" * self.col_width) for h in self.header])
+
+        if not self.quiet:
+            self.print_tabbed([("-" * self.col_width) for _h in self.header])
 
     def add_row(self, row):
         if self.open:
@@ -30,7 +38,7 @@ class Table(object):
 
     def close(self):
         if self.open:
-            self.print_boarder()
+            self.print_border()
             lock.release()
             self.open = False
 

--- a/bond/commands/backup.py
+++ b/bond/commands/backup.py
@@ -1,14 +1,16 @@
-from .base_command import BaseCommand
-from bond.database import BondDatabase, DB_DIRNAME
-import bond.proto
-import requests.exceptions
-from http.server import HTTPServer, SimpleHTTPRequestHandler
-import time
-from threading import Thread
-from queue import Queue
-from pathlib import Path
 import datetime
 import os
+import time
+from http.server import HTTPServer, SimpleHTTPRequestHandler
+from pathlib import Path
+from queue import Queue
+from threading import Thread
+
+import requests.exceptions
+
+import bond.proto
+from bond.commands.base_command import BaseCommand
+from bond.database import BondDatabase, DB_DIRNAME
 
 Q = Queue()
 

--- a/bond/commands/device_create.py
+++ b/bond/commands/device_create.py
@@ -1,6 +1,5 @@
 import bond.proto
 from bond.commands.base_command import BaseCommand
-from bond.commands.devices import DevicesCommand
 from bond.database import BondDatabase
 
 

--- a/bond/commands/device_create.py
+++ b/bond/commands/device_create.py
@@ -23,10 +23,13 @@ class DeviceCreateCommand(BaseCommand):
             "type": int,
             "required": False,
         },
+        "--bondid": {
+            "help": "ignore selected Bond and use provided"
+        },
     }
 
     def run(self, args):
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
         properties = {}
         if args.addr:
             properties["addr"] = args.addr
@@ -37,7 +40,7 @@ class DeviceCreateCommand(BaseCommand):
         if args.zero_gap:
             properties["zero_gap"] = args.zero_gap
         rsp = bond.proto.post(
-            bondid,
+            bond_id,
             topic="devices",
             body={
                 "name": args.name,

--- a/bond/commands/device_create.py
+++ b/bond/commands/device_create.py
@@ -10,7 +10,10 @@ class DeviceCreateCommand(BaseCommand):
     arguments = {
         "--name": {"help": "device name", "required": True},
         "--template": {"help": "template name (RCF84, A1, etc.)", "required": True},
-        "--location": {"help": "location name (Bedroom, Living Room, etc.)", "required": True},
+        "--location": {
+            "help": "location name (Bedroom, Living Room, etc.)",
+            "required": True,
+        },
         "--addr": {"help": "device address (binary)", "required": False},
         "--freq": {"help": "signal frequency (kHz)", "type": int, "required": False},
         "--bps": {
@@ -23,9 +26,7 @@ class DeviceCreateCommand(BaseCommand):
             "type": int,
             "required": False,
         },
-        "--bondid": {
-            "help": "ignore selected Bond and use provided"
-        },
+        "--bondid": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):

--- a/bond/commands/device_create.py
+++ b/bond/commands/device_create.py
@@ -1,8 +1,7 @@
 import bond.proto
+from bond.commands.base_command import BaseCommand
+from bond.commands.devices import DevicesCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
-from .devices import DevicesCommand
 
 
 class DeviceCreateCommand(BaseCommand):

--- a/bond/commands/device_create.py
+++ b/bond/commands/device_create.py
@@ -48,7 +48,6 @@ class DeviceCreateCommand(BaseCommand):
         )
         if rsp["s"] > 299:
             print("HTTP %d %s" % (rsp["s"], rsp["b"]["_error_msg"]))
-        DevicesCommand().run(None)
 
 
 def register():

--- a/bond/commands/devices.py
+++ b/bond/commands/devices.py
@@ -18,8 +18,9 @@ class DevicesCommand(BaseCommand):
         if not args.q:
             print("Devices on %s" % bond_id)
         with Table(["dev_id", "name", "location"], quiet=args.q) as table:
-            dev_ids.pop("_", None)
             for dev_id in dev_ids:
+                if dev_id.startswith("_"):
+                    continue
                 dev = bond.proto.get(bond_id, topic="devices/%s" % dev_id).get("b", {})
                 table.add_row(
                     {

--- a/bond/commands/devices.py
+++ b/bond/commands/devices.py
@@ -8,11 +8,12 @@ class DevicesCommand(BaseCommand):
     subcmd = "devices"
     help = "Interact with the selected Bond's devices."
     arguments = {
+        "--bondid": {"help": "ignore selected Bond and use provided ID"},
         "-q": {"help": "dont print table outline (quiet mode)", "action": "store_true"},
     }
 
     def run(self, args):
-        bond_id = BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
         dev_ids = bond.proto.get(bond_id, topic="devices").get("b", {})
         if not args.q:
             print("Devices on %s" % bond_id)

--- a/bond/commands/devices.py
+++ b/bond/commands/devices.py
@@ -7,12 +7,16 @@ from bond.database import BondDatabase
 class DevicesCommand(BaseCommand):
     subcmd = "devices"
     help = "Interact with the selected Bond's devices."
+    arguments = {
+        "-q": {"help": "dont print table outline (quiet mode)", "action": "store_true"},
+    }
 
     def run(self, args):
         bond_id = BondDatabase.get_assert_selected_bondid()
         dev_ids = bond.proto.get(bond_id, topic="devices").get("b", {})
-        print("Devices on %s" % bond_id)
-        with Table(["dev_id", "name", "location"]) as table:
+        if not args.q:
+            print("Devices on %s" % bond_id)
+        with Table(["dev_id", "name", "location"], quiet=args.q) as table:
             dev_ids.pop("_", None)
             for dev_id in dev_ids:
                 dev = bond.proto.get(bond_id, topic="devices/%s" % dev_id).get("b", {})

--- a/bond/commands/devices.py
+++ b/bond/commands/devices.py
@@ -1,8 +1,7 @@
 import bond.proto
 from bond.cli.table import Table
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 class DevicesCommand(BaseCommand):

--- a/bond/commands/devices_clear.py
+++ b/bond/commands/devices_clear.py
@@ -7,15 +7,11 @@ class DevicesClearCommand(BaseCommand):
     subcmd = "devices_clear"
     help = "Remove all Bond's devices."
     arguments = {
-        "--bondid": {
-            "help": "ignore selected Bond and use provided"
-        },
-        "--deviceid": {
-            "help": "delete single device"
-        },
+        "--bondid": {"help": "ignore selected Bond and use provided"},
+        "--deviceid": {"help": "delete single device"},
         "--force": {
             "help": "force deletion with no input from user",
-            "action": "store_true"
+            "action": "store_true",
         },
     }
 

--- a/bond/commands/devices_clear.py
+++ b/bond/commands/devices_clear.py
@@ -1,0 +1,35 @@
+import bond.proto
+from bond.commands.base_command import BaseCommand
+from bond.database import BondDatabase
+
+
+class DevicesClearCommand(BaseCommand):
+    subcmd = "devices_clear"
+    help = "Remove all Bond's devices."
+    arguments = {
+        "--bondid": {
+            "help": "ignore selected Bond and use provided"
+        },
+        "--deviceid": {
+            "help": "delete single device"
+        },
+        "--force": {
+            "help": "force deletion with no input from user",
+            "action": "store_true"
+        },
+    }
+
+    def run(self, args):
+        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        dev_ids = bond.proto.get(bond_id, topic="devices").get("b", {})
+        dev_ids.pop("_", None)
+        for dev_id in dev_ids:
+            if args.deviceid and not args.deviceid == dev_id:
+                continue
+            if args.force or input(f"Delete device {dev_id}? [N/y] ").lower() == "y":
+                bond.proto.delete(bond_id, topic="devices/%s" % dev_id)
+                print(dev_id + " device deleted (" + bond_id + ")")
+
+
+def register():
+    DevicesClearCommand()

--- a/bond/commands/discover.py
+++ b/bond/commands/discover.py
@@ -8,9 +8,10 @@ from bond.proto.mdns import Scanner
 class DiscoverCommand(BaseCommand):
     subcmd = "discover"
     help = "Discover Bonds on local network."
+    arguments = {"-q": {"help": "dont print table outline (quiet mode)", "action": "store_true"}}
 
     def run(self, args):
-        table = Table(["bondid", "ip", "port"])
+        table = Table(["bondid", "ip", "port"], quiet=args.q)
         scanner = Scanner(table.add_row)    # noqa: F841
         try:
             time.sleep(5)

--- a/bond/commands/discover.py
+++ b/bond/commands/discover.py
@@ -1,9 +1,8 @@
 import time
 
 from bond.cli.table import Table
+from bond.commands.base_command import BaseCommand
 from bond.proto.mdns import Scanner
-
-from .base_command import BaseCommand
 
 
 class DiscoverCommand(BaseCommand):

--- a/bond/commands/discover.py
+++ b/bond/commands/discover.py
@@ -8,11 +8,13 @@ from bond.proto.mdns import Scanner
 class DiscoverCommand(BaseCommand):
     subcmd = "discover"
     help = "Discover Bonds on local network."
-    arguments = {"-q": {"help": "dont print table outline (quiet mode)", "action": "store_true"}}
+    arguments = {
+        "-q": {"help": "dont print table outline (quiet mode)", "action": "store_true"}
+    }
 
     def run(self, args):
         table = Table(["bondid", "ip", "port"], quiet=args.q)
-        scanner = Scanner(table.add_row)    # noqa: F841
+        scanner = Scanner(table.add_row)  # noqa: F841
         try:
             time.sleep(5)
         except KeyboardInterrupt:

--- a/bond/commands/group_create.py
+++ b/bond/commands/group_create.py
@@ -1,0 +1,36 @@
+import bond.proto
+from bond.commands.base_command import BaseCommand
+from bond.database import BondDatabase
+
+
+class GroupCreateCommand(BaseCommand):
+    subcmd = "group_create"
+    help = "Create a new group."
+    arguments = {
+        "--name": {"help": "group name", "required": True},
+        "--devices": {"help": "included devices", "required": True},
+        "--groupid": {"help": "group ID (optional)", "required": False},
+        "--bondid": {"help": "ignore selected Bond and use provided"},
+    }
+
+    def run(self, args):
+        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        create_group_body = {
+            "name": args.name,
+            "devices": args.devices.split(","),
+        }
+
+        if args.groupid:
+            create_group_body["_id"] = args.groupid
+
+        rsp = bond.proto.post(
+            bond_id,
+            topic="groups",
+            body=create_group_body,
+        )
+        if rsp["s"] > 299:
+            print("HTTP %d %s" % (rsp["s"], rsp["b"]["_error_msg"]))
+
+
+def register():
+    GroupCreateCommand()

--- a/bond/commands/groups.py
+++ b/bond/commands/groups.py
@@ -1,0 +1,40 @@
+import bond.proto
+from bond.cli.table import Table
+from bond.commands.base_command import BaseCommand
+from bond.database import BondDatabase
+
+
+class GroupsCommand(BaseCommand):
+    subcmd = "groups"
+    help = "Interact with the selected Bond's groups."
+    arguments = {
+        "--bondid": {
+            "help": "ignore selected Bond and use provided"
+        },
+        "-q": {
+            "help": "dont print table outline (quiet mode)",
+            "action": "store_true",
+        },
+    }
+
+    def run(self, args):
+        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        group_ids = bond.proto.get(bond_id, topic="groups").get("b", {})
+        if not args.q:
+            print("Groups on %s" % bond_id)
+        with Table(["group_id", "name", "types", "devices"], quiet=args.q) as table:
+            group_ids.pop("_", None)
+            for group_id in group_ids:
+                group = bond.proto.get(bond_id, topic="groups/%s" % group_id).get("b", {})
+                table.add_row(
+                    {
+                        "group_id": group_id,
+                        "name": group.get("name"),
+                        "types": group.get("types"),
+                        "devices": group.get("devices"),
+                    }
+                )
+
+
+def register():
+    GroupsCommand()

--- a/bond/commands/groups.py
+++ b/bond/commands/groups.py
@@ -8,9 +8,7 @@ class GroupsCommand(BaseCommand):
     subcmd = "groups"
     help = "Interact with the selected Bond's groups."
     arguments = {
-        "--bondid": {
-            "help": "ignore selected Bond and use provided"
-        },
+        "--bondid": {"help": "ignore selected Bond and use provided"},
         "-q": {
             "help": "dont print table outline (quiet mode)",
             "action": "store_true",
@@ -25,7 +23,9 @@ class GroupsCommand(BaseCommand):
         with Table(["group_id", "name", "types", "devices"], quiet=args.q) as table:
             group_ids.pop("_", None)
             for group_id in group_ids:
-                group = bond.proto.get(bond_id, topic="groups/%s" % group_id).get("b", {})
+                group = bond.proto.get(bond_id, topic="groups/%s" % group_id).get(
+                    "b", {}
+                )
                 table.add_row(
                     {
                         "group_id": group_id,

--- a/bond/commands/groups.py
+++ b/bond/commands/groups.py
@@ -21,8 +21,9 @@ class GroupsCommand(BaseCommand):
         if not args.q:
             print("Groups on %s" % bond_id)
         with Table(["group_id", "name", "types", "devices"], quiet=args.q) as table:
-            group_ids.pop("_", None)
             for group_id in group_ids:
+                if group_id.startswith("_"):
+                    continue
                 group = bond.proto.get(bond_id, topic="groups/%s" % group_id).get(
                     "b", {}
                 )

--- a/bond/commands/groups_clear.py
+++ b/bond/commands/groups_clear.py
@@ -5,7 +5,7 @@ from bond.database import BondDatabase
 
 class GroupsClearCommand(BaseCommand):
     subcmd = "groups_clear"
-    help = "Remove all Bond's devices."
+    help = "Remove all Bond's groups."
     arguments = {
         "--bondid": {"help": "ignore selected Bond and use provided"},
         "--groupid": {"help": "delete single group"},

--- a/bond/commands/groups_clear.py
+++ b/bond/commands/groups_clear.py
@@ -7,15 +7,11 @@ class GroupsClearCommand(BaseCommand):
     subcmd = "groups_clear"
     help = "Remove all Bond's devices."
     arguments = {
-        "--bondid": {
-            "help": "ignore selected Bond and use provided"
-        },
-        "--groupid": {
-            "help": "delete single group"
-        },
+        "--bondid": {"help": "ignore selected Bond and use provided"},
+        "--groupid": {"help": "delete single group"},
         "--force": {
             "help": "force deletion with no input from user",
-            "action": "store_true"
+            "action": "store_true",
         },
     }
 

--- a/bond/commands/groups_clear.py
+++ b/bond/commands/groups_clear.py
@@ -1,0 +1,37 @@
+import bond.proto
+from bond.commands.base_command import BaseCommand
+from bond.database import BondDatabase
+
+
+class GroupsClearCommand(BaseCommand):
+    subcmd = "groups_clear"
+    help = "Remove all Bond's devices."
+    arguments = {
+        "--bondid": {
+            "help": "ignore selected Bond and use provided"
+        },
+        "--groupid": {
+            "help": "delete single group"
+        },
+        "--force": {
+            "help": "force deletion with no input from user",
+            "action": "store_true"
+        },
+    }
+
+    def run(self, args):
+        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+
+        group_ids = bond.proto.get(bond_id, topic="groups").get("b", {})
+        group_ids.pop("_", None)
+
+        for group_id in group_ids:
+            if args.groupid and not args.groupid == group_id:
+                continue
+            if args.force or input(f"Delete group {group_id}? [N/y] ").lower() == "y":
+                bond.proto.delete(bond_id, topic="groups/%s" % group_id)
+                print(group_id + " group deleted (" + bond_id + ")")
+
+
+def register():
+    GroupsClearCommand()

--- a/bond/commands/list.py
+++ b/bond/commands/list.py
@@ -6,14 +6,17 @@ from bond.database import BondDatabase
 class ListCommand(BaseCommand):
     subcmd = "list"
     help = "List Bonds in local database."
-    arguments = {"--clear": {"action": "store_true", "help": "clear discovered Bonds"}}
+    arguments = {
+        "--clear": {"action": "store_true", "help": "clear discovered Bonds"},
+        "-q": {"help": "dont print table outline (quiet mode)", "action": "store_true"},
+    }
 
     def run(self, args):
         if args.clear:
             BondDatabase().pop("bonds", None)
             print("Cleared discovered Bonds")
         else:
-            table = Table(["bondid", "ip", "token"])
+            table = Table(["bondid", "ip", "token"], quiet=args.q)
             bonds = BondDatabase.get_bonds()
             for bondid in bonds.keys():
                 b = bonds[bondid]

--- a/bond/commands/list.py
+++ b/bond/commands/list.py
@@ -1,7 +1,6 @@
 from bond.cli.table import Table
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 class ListCommand(BaseCommand):

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -8,9 +8,8 @@ import time
 from requests.exceptions import RequestException
 
 import bond.proto
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 LEVEL_MAP = {"warn": 2, "info": 3, "debug": 4, "trace": 5}
 

--- a/bond/commands/reboot.py
+++ b/bond/commands/reboot.py
@@ -1,9 +1,8 @@
 import requests.exceptions
 
 import bond.proto
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 class RebootCommand(BaseCommand):

--- a/bond/commands/reset.py
+++ b/bond/commands/reset.py
@@ -1,7 +1,6 @@
 import bond.proto
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 class ResetCommand(BaseCommand):

--- a/bond/commands/rfman.py
+++ b/bond/commands/rfman.py
@@ -1,7 +1,6 @@
 import bond.proto
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 class RFManCommand(BaseCommand):

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -54,7 +54,7 @@ class SelectCommand(BaseCommand):
                 BondDatabase.set_bond(bond_id, "port", args.port)
                 print("Set %s port %s" % (bond_id, args.ip))
             print("Selected Bond: %s" % BondDatabase().get("selected_bondid"))
-            token = check_unlocked_token()    # noqa: F841
+            token = check_unlocked_token()  # noqa: F841
         elif args.clear:
             BondDatabase().pop("selected_bondid", None)
             print("Cleared selected Bond")

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -1,7 +1,6 @@
+from bond.commands.base_command import BaseCommand
+from bond.commands.token import check_unlocked_token
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
-from .token import check_unlocked_token
 
 
 class SelectCommand(BaseCommand):

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -58,6 +58,8 @@ class SelectCommand(BaseCommand):
         elif args.clear:
             BondDatabase().pop("selected_bondid", None)
             print("Cleared selected Bond")
+        else:
+            print("Bond selected: " + BondDatabase().get_assert_selected_bondid())
 
 
 def register():

--- a/bond/commands/signal.py
+++ b/bond/commands/signal.py
@@ -18,7 +18,7 @@ class SignalCommand(BaseCommand):
         "--encoding": {"help": "The signal encoding", "default": "cq"},
         "--modulation": {"help": "The signal modulation", "default": "OOK"},
         "--use-scan": {
-            "help": "Whether or not to use the most recently-scanned buffer (takes precedence over all other arguments!)",
+            "help": "Whether or not to use the most recently-scanned buffer (takes precedence over all other arguments!)",  # noqa: E501
             "action": "store_true",
         },
     }

--- a/bond/commands/signal.py
+++ b/bond/commands/signal.py
@@ -1,7 +1,6 @@
 import bond.proto
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 class SignalCommand(BaseCommand):

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -38,9 +38,13 @@ class TokenCommand(BaseCommand):
             print(f"{bond_id}'s token is not unlocked.")
             stored_token = BondDatabase.get_bond(bond_id).get("token")
             if stored_token:
-                print(f"There's already a token for {bond_id} in your local database: {stored_token}.")
+                print(
+                    f"There's already a token for {bond_id} in your local database: {stored_token}."
+                )
                 print("If this token is obsolete, you will need to set the new token.")
-                print("You can set it manually with 'bond token <token>', or unlock the token and run 'bond token'")
+                print(
+                    "You can set it manually with 'bond token <token>', or unlock the token and run 'bond token'"
+                )
                 print("(tip: the token is unlocked for a short period after a reboot)")
 
 

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -1,7 +1,6 @@
 import bond.proto
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 def update_token(token, bond_id=None):

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -9,7 +9,7 @@ def update_token(token, bond_id=None):
     if bond_id not in bonds.keys():
         bonds[bond_id] = dict()
     bonds[bond_id]["token"] = token
-    print("Updated token for %s" % bond_id)
+    print(f"Updated token for {bond_id}")
     BondDatabase.set("bonds", bonds)
 
 
@@ -25,24 +25,22 @@ def check_unlocked_token(bond_id=None):
 class TokenCommand(BaseCommand):
     subcmd = "token"
     help = "Manage token-based authentication."
-    arguments = {"token": {"help": "Save Bond token to local database", "nargs": "?"}}
+    arguments = {
+        "token": {"help": "Save Bond token to local database", "nargs": "?"},
+        "--bondid": {"help": "ignore selected Bond and use provided"},
+    }
 
     def run(self, args):
-        bond_id = BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
         if args.token:
             update_token(args.token, bond_id)
         elif not check_unlocked_token(bond_id):
-            print("%s's token is not unlocked." % bond_id)
+            print(f"{bond_id}'s token is not unlocked.")
             stored_token = BondDatabase.get_bond(bond_id).get("token")
             if stored_token:
-                print(
-                    "There's already a token for %s in your local database: %s."
-                    % (bond_id, stored_token)
-                )
+                print(f"There's already a token for {bond_id} in your local database: {stored_token}.")
                 print("If this token is obsolete, you will need to set the new token.")
-                print(
-                    "You can set it manually with 'bond token <token>', or unlock the token and run 'bond token'"
-                )
+                print("You can set it manually with 'bond token <token>', or unlock the token and run 'bond token'")
                 print("(tip: the token is unlocked for a short period after a reboot)")
 
 

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -98,12 +98,15 @@ class UpgradeCommand(BaseCommand):
             "type": int,
             "default": 0,
         },
+        "--bondid": {
+            "help": "ignore selected Bond and use provided"
+        },
     }
 
     def run(self, args):
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
         print("Connecting to BOND...")
-        sys_version = bond.proto.get(bondid, topic="sys/version")["b"]
+        sys_version = bond.proto.get(bond_id, topic="sys/version")["b"]
         target = sys_version["target"]
         current_ver = sys_version["fw_ver"]
         print(f"Detected Target: \t{target}")
@@ -135,4 +138,4 @@ class UpgradeCommand(BaseCommand):
         if input("Are you sure? [N/y] ").lower() != "y":
             raise SystemExit("Pfew. That was close. Aborting!")
         print("Requesting upgrade...")
-        do_upgrade(bondid, version_obj)
+        do_upgrade(bond_id, version_obj)

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -98,6 +98,10 @@ class UpgradeCommand(BaseCommand):
             "type": int,
             "default": 0,
         },
+        "--force": {
+            "help": "force upgrade with no input from user",
+            "action": "store_true"
+        },
         "--bondid": {
             "help": "ignore selected Bond and use provided"
         },
@@ -135,7 +139,7 @@ class UpgradeCommand(BaseCommand):
         print(f"Installing Version: \t{new_ver}")
         if new_ver == current_ver:
             print("WARNING: Versions are identical.")
-        if input("Are you sure? [N/y] ").lower() != "y":
+        if not args.force and input("Are you sure? [N/y] ").lower() != "y":
             raise SystemExit("Pfew. That was close. Aborting!")
         print("Requesting upgrade...")
         do_upgrade(bond_id, version_obj)

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -100,11 +100,9 @@ class UpgradeCommand(BaseCommand):
         },
         "--force": {
             "help": "force upgrade with no input from user",
-            "action": "store_true"
+            "action": "store_true",
         },
-        "--bondid": {
-            "help": "ignore selected Bond and use provided"
-        },
+        "--bondid": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -5,9 +5,8 @@ import time
 import requests
 
 import bond.proto
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 def register():

--- a/bond/commands/version.py
+++ b/bond/commands/version.py
@@ -1,7 +1,6 @@
 import bond.proto
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 class VersionCommand(BaseCommand):

--- a/bond/commands/version.py
+++ b/bond/commands/version.py
@@ -6,9 +6,14 @@ from bond.database import BondDatabase
 class VersionCommand(BaseCommand):
     subcmd = "version"
     help = "Get firmware version and target of the selected Bond."
+    arguments = {
+        "--bondid": {
+            "help": "ignore selected Bond and use provided"
+        }
+    }
 
     def run(self, args):
-        bond_id = BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
         rsp = bond.proto.get(bond_id, topic="sys/version")
         body = rsp.get("b", {})
         print(bond_id)

--- a/bond/commands/version.py
+++ b/bond/commands/version.py
@@ -6,11 +6,7 @@ from bond.database import BondDatabase
 class VersionCommand(BaseCommand):
     subcmd = "version"
     help = "Get firmware version and target of the selected Bond."
-    arguments = {
-        "--bondid": {
-            "help": "ignore selected Bond and use provided"
-        }
-    }
+    arguments = {"--bondid": {"help": "ignore selected Bond and use provided"}}
 
     def run(self, args):
         bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()

--- a/bond/commands/wifi.py
+++ b/bond/commands/wifi.py
@@ -1,9 +1,8 @@
 from base64 import b64encode
 
 import bond.proto
+from bond.commands.base_command import BaseCommand
 from bond.database import BondDatabase
-
-from .base_command import BaseCommand
 
 
 class WifiCommand(BaseCommand):

--- a/bond/database/__init__.py
+++ b/bond/database/__init__.py
@@ -1,1 +1,1 @@
-from .database import BondDatabase, DB_DIRNAME  # noqa: F401
+from bond.database.database import BondDatabase, DB_DIRNAME  # noqa: F401

--- a/bond/proto/__init__.py
+++ b/bond/proto/__init__.py
@@ -1,1 +1,9 @@
-from bond.proto.wye import get, put, post, patch, delete, get_all_async, get_async  # noqa: F401
+from bond.proto.wye import (
+    get,
+    put,
+    post,
+    patch,
+    delete,
+    get_all_async,
+    get_async,
+)  # noqa: F401

--- a/bond/proto/__init__.py
+++ b/bond/proto/__init__.py
@@ -1,9 +1,1 @@
-from bond.proto.wye import (
-    get,
-    put,
-    post,
-    patch,
-    delete,
-    get_all_async,
-    get_async,
-)  # noqa: F401
+from bond.proto.wye import get, put, post, patch, delete, get_all_async, get_async  # noqa: F401

--- a/bond/proto/__init__.py
+++ b/bond/proto/__init__.py
@@ -1,1 +1,1 @@
-from .wye import get, put, post, patch, delete, get_all_async, get_async  # noqa: F401
+from bond.proto.wye import get, put, post, patch, delete, get_all_async, get_async  # noqa: F401

--- a/bond/proto/http.py
+++ b/bond/proto/http.py
@@ -2,7 +2,7 @@ import json
 
 import requests
 
-from .base_transport import BaseTransport
+from bond.proto.base_transport import BaseTransport
 
 
 class HTTP_Transport(BaseTransport):

--- a/bond/proto/mdns.py
+++ b/bond/proto/mdns.py
@@ -28,7 +28,9 @@ class Scanner(object):
     def __init__(self, on_success):
         self.zeroconf = Zeroconf()
         self.listener = Listener(on_success=on_success)
-        browser = ServiceBrowser(self.zeroconf, "_bond._tcp.local.", self.listener)    # noqa: F841
+        browser = ServiceBrowser(
+            self.zeroconf, "_bond._tcp.local.", self.listener
+        )  # noqa: F841
 
     def __del__(self):
         del self.listener

--- a/bond/proto/mdns.py
+++ b/bond/proto/mdns.py
@@ -28,9 +28,7 @@ class Scanner(object):
     def __init__(self, on_success):
         self.zeroconf = Zeroconf()
         self.listener = Listener(on_success=on_success)
-        browser = ServiceBrowser(
-            self.zeroconf, "_bond._tcp.local.", self.listener
-        )  # noqa: F841
+        _browser = ServiceBrowser(self.zeroconf, "_bond._tcp.local.", self.listener)  # noqa: F841
 
     def __del__(self):
         del self.listener

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ DEPS_TEST = DEPS_ALL + open("requirements-test.txt").readlines()
 
 setup(
     name="bond-cli",
-    version="0.0.14",
+    version="0.1.0",
     author="Olibra",
     packages=find_packages(),
     scripts=["bond/bond"],


### PR DESCRIPTION
- Adds the following commands:
  - `groups`
  - `group_create`
  - `groups_clear`
  - `devices_clear`
- Adds `--bondid` option to the following commands (ignores selected bond):
  - `devices`
  - `device_create`
  - `token`
  - `upgrade`
  - `version`
- Adds `-q` option for removing table outline from output for the following commands:
  - `devices`
  - `discover`
  - `list`
- Adds the `--force` option to the `upgrade` command, removing the need for user input
- Ignores all entries in devices/groups list starting with `_` (fixes `__` bug)
- Increases table column width from `16` to `20`
- Fixes `flake8` long line warning
- Runs [`Black`](https://github.com/psf/black) linter on code base (with some exceptions where `flake8` broke)
- Bumps version from `0.0.14` to `0.1.0` (see [semver.org](https://semver.org/#how-should-i-deal-with-revisions-in-the-0yz-initial-development-phase))