### PR TITLE
ID arguments

### DIFF
--- a/bond/commands/backup.py
+++ b/bond/commands/backup.py
@@ -60,11 +60,13 @@ def wait_upload(timeout=None):
 class BackupCommand(object):
     subcmd = "backup"
     help = """Backup a Bond"""
-    arguments = {}
+    arguments = {
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
+    }
 
     def run(self, args):
         start_daemon(4444)
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bondid = args.bond_id or BondDatabase.get_assert_selected_bondid()
         timestamp = str(int(time.time()))
         body = {
             "backup": 1,
@@ -132,6 +134,7 @@ class RestoreCommand(object):
             "help": "Only for test purposes. May cause unexpected behavior.",
             "action": "store_true",
         },
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):  # noqa: C901
@@ -152,7 +155,7 @@ class RestoreCommand(object):
             args.file = file_list[-1]["file"]
 
         start_daemon(4444)
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bondid = args.bond_id or BondDatabase.get_assert_selected_bondid()
         # timestamp = str(int(time.time()))
         body = {
             "restore": 1,

--- a/bond/commands/devices/create.py
+++ b/bond/commands/devices/create.py
@@ -50,3 +50,5 @@ class DeviceCreateCommand(object):
         )
         if rsp["s"] > 299:
             print(f"HTTP {rsp['s']} {rsp['b']['_error_msg']}")
+        else:
+            print(f"{rsp['b']['_id']} device created.")

--- a/bond/commands/devices/create.py
+++ b/bond/commands/devices/create.py
@@ -24,11 +24,11 @@ class DeviceCreateCommand(object):
             "type": int,
             "required": False,
         },
-        "--bondid": {"help": "ignore selected Bond and use provided"},
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):
-        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         properties = {}
         if args.addr:
             properties["addr"] = args.addr

--- a/bond/commands/devices/delete.py
+++ b/bond/commands/devices/delete.py
@@ -15,7 +15,9 @@ class DeviceDeleteCommand(object):
 
     def setup(self, parser):
         group = parser.add_mutually_exclusive_group()
-        group.add_argument("--device-ids", help="ID of the device(s) being deleted", nargs="*")
+        group.add_argument(
+            "--device-ids", help="ID of the device(s) being deleted", nargs="*"
+        )
         group.add_argument("--all", help="delete all devices", action="store_true")
 
     def run(self, args):

--- a/bond/commands/devices/delete.py
+++ b/bond/commands/devices/delete.py
@@ -6,7 +6,7 @@ class DeviceDeleteCommand(object):
     subcmd = "delete"
     help = "Delete Bond's devices."
     arguments = {
-        "--bondid": {"help": "ignore selected Bond and use provided"},
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
         "--force": {
             "help": "force deletion with no input from user",
             "action": "store_true",
@@ -15,11 +15,11 @@ class DeviceDeleteCommand(object):
 
     def setup(self, parser):
         group = parser.add_mutually_exclusive_group()
-        group.add_argument("--device_id", help="ID of the device being deleted")
+        group.add_argument("--device-id", help="ID of the device being deleted")
         group.add_argument("--all", help="delete all devices", action="store_true")
 
     def run(self, args):
-        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         if args.all:
             if (
                 args.force

--- a/bond/commands/devices/delete.py
+++ b/bond/commands/devices/delete.py
@@ -15,7 +15,7 @@ class DeviceDeleteCommand(object):
 
     def setup(self, parser):
         group = parser.add_mutually_exclusive_group()
-        group.add_argument("--device-id", help="ID of the device being deleted")
+        group.add_argument("--device-ids", help="ID of the device(s) being deleted", nargs="*")
         group.add_argument("--all", help="delete all devices", action="store_true")
 
     def run(self, args):
@@ -26,13 +26,14 @@ class DeviceDeleteCommand(object):
                 or input(f"Delete all devices from {bond_id}? [N/y] ").lower() == "y"
             ):
                 self.delete_all_devices(bond_id)
-        elif args.device_id:
+        elif args.device_ids:
             if (
                 args.force
-                or input(f"Delete device {args.device_id}? [N/y] ").lower() == "y"
+                or input(f"Delete device(s) {args.device_ids}? [N/y] ").lower() == "y"
             ):
-                bond.proto.delete(bond_id, topic=f"devices/{args.device_id}")
-                print(f"{args.device_id} device deleted.")
+                for dev_id in args.device_ids:
+                    bond.proto.delete(bond_id, topic=f"devices/{dev_id}")
+                    print(f"{dev_id} device deleted.")
 
     def delete_all_devices(self, bond_id):
         dev_ids = bond.proto.get(bond_id, topic="devices").get("b", {})

--- a/bond/commands/devices/list.py
+++ b/bond/commands/devices/list.py
@@ -7,12 +7,12 @@ class DevicesListCommand(object):
     subcmd = "list"
     help = "List the selected Bond's devices."
     arguments = {
-        "--bondid": {"help": "ignore selected Bond and use provided ID"},
+        "--bond-id": {"help": "ignore selected Bond and use provided ID"},
         "-q": {"help": "dont print table outline (quiet mode)", "action": "store_true"},
     }
 
     def run(self, args):
-        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         dev_ids = bond.proto.get(bond_id, topic="devices").get("b", {})
         if not args.q:
             print(f"Devices on {bond_id}:")

--- a/bond/commands/groups/create.py
+++ b/bond/commands/groups/create.py
@@ -8,19 +8,19 @@ class GroupCreateCommand(object):
     arguments = {
         "--name": {"help": "group name", "required": True},
         "--devices": {"help": "included devices", "required": True},
-        "--groupid": {"help": "group ID (optional)", "required": False},
-        "--bondid": {"help": "ignore selected Bond and use provided"},
+        "--group-id": {"help": "group ID (optional)", "required": False},
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):
-        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         create_group_body = {
             "name": args.name,
             "devices": args.devices.split(","),
         }
 
-        if args.groupid:
-            create_group_body["_id"] = args.groupid
+        if args.group_id:
+            create_group_body["_id"] = args.group_id
 
         rsp = bond.proto.post(
             bond_id,

--- a/bond/commands/groups/create.py
+++ b/bond/commands/groups/create.py
@@ -7,7 +7,7 @@ class GroupCreateCommand(object):
     help = "Create a new group."
     arguments = {
         "--name": {"help": "group name", "required": True},
-        "--devices": {"help": "included devices", "required": True, "nargs": "*"},
+        "--device-ids": {"help": "included devices", "required": True, "nargs": "*"},
         "--group-id": {"help": "predefine group ID (optional)", "required": False},
         "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
@@ -16,7 +16,7 @@ class GroupCreateCommand(object):
         bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         create_group_body = {
             "name": args.name,
-            "devices": args.devices,
+            "devices": args.device_ids,
         }
 
         if args.group_id:

--- a/bond/commands/groups/create.py
+++ b/bond/commands/groups/create.py
@@ -29,3 +29,5 @@ class GroupCreateCommand(object):
         )
         if rsp["s"] > 299:
             print(f"HTTP {rsp['s']} {rsp['b']['_error_msg']}")
+        else:
+            print(f"{rsp['b']['_id']} group created.")

--- a/bond/commands/groups/create.py
+++ b/bond/commands/groups/create.py
@@ -7,8 +7,8 @@ class GroupCreateCommand(object):
     help = "Create a new group."
     arguments = {
         "--name": {"help": "group name", "required": True},
-        "--devices": {"help": "included devices", "required": True},
-        "--group-id": {"help": "group ID (optional)", "required": False},
+        "--devices": {"help": "included devices", "required": True, "nargs": "*"},
+        "--group-id": {"help": "predefine group ID (optional)", "required": False},
         "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
@@ -16,7 +16,7 @@ class GroupCreateCommand(object):
         bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         create_group_body = {
             "name": args.name,
-            "devices": args.devices.split(","),
+            "devices": args.devices,
         }
 
         if args.group_id:

--- a/bond/commands/groups/delete.py
+++ b/bond/commands/groups/delete.py
@@ -15,7 +15,9 @@ class GroupDeleteCommand(object):
 
     def setup(self, parser):
         group = parser.add_mutually_exclusive_group()
-        group.add_argument("--group-ids", help="ID of the group(s) being deleted", nargs="*")
+        group.add_argument(
+            "--group-ids", help="ID of the group(s) being deleted", nargs="*"
+        )
         group.add_argument("--all", help="delete all groups", action="store_true")
 
     def run(self, args):

--- a/bond/commands/groups/delete.py
+++ b/bond/commands/groups/delete.py
@@ -6,7 +6,7 @@ class GroupDeleteCommand(object):
     subcmd = "delete"
     help = "Delete Bond's groups."
     arguments = {
-        "--bondid": {"help": "ignore selected Bond and use provided"},
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
         "--force": {
             "help": "force deletion with no input from user",
             "action": "store_true",
@@ -19,7 +19,7 @@ class GroupDeleteCommand(object):
         group.add_argument("--all", help="delete all groups", action="store_true")
 
     def run(self, args):
-        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         if args.all:
             if (
                 args.force

--- a/bond/commands/groups/delete.py
+++ b/bond/commands/groups/delete.py
@@ -15,7 +15,7 @@ class GroupDeleteCommand(object):
 
     def setup(self, parser):
         group = parser.add_mutually_exclusive_group()
-        group.add_argument("--group_id", help="ID of the group being deleted")
+        group.add_argument("--group-ids", help="ID of the group(s) being deleted", nargs="*")
         group.add_argument("--all", help="delete all groups", action="store_true")
 
     def run(self, args):
@@ -26,13 +26,14 @@ class GroupDeleteCommand(object):
                 or input(f"Delete all groups from {bond_id}? [N/y] ").lower() == "y"
             ):
                 self.delete_all_groups(bond_id)
-        elif args.group_id:
+        elif args.group_ids:
             if (
                 args.force
-                or input(f"Delete group {args.group_id}? [N/y] ").lower() == "y"
+                or input(f"Delete group(s) {args.group_ids}? [N/y] ").lower() == "y"
             ):
-                bond.proto.delete(bond_id, topic=f"groups/{args.group_id}")
-                print(f"{args.group_id} group deleted.")
+                for group_id in args.group_ids:
+                    bond.proto.delete(bond_id, topic=f"groups/{group_id}")
+                    print(f"{group_id} group deleted.")
 
     def delete_all_groups(self, bond_id):
         groups_ids = bond.proto.get(bond_id, topic="groups").get("b", {})

--- a/bond/commands/groups/list.py
+++ b/bond/commands/groups/list.py
@@ -8,7 +8,7 @@ class GroupsListCommand(object):
     help = "List the selected Bond's groups."
 
     arguments = {
-        "--bondid": {"help": "ignore selected Bond and use provided"},
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
         "-q": {
             "help": "dont print table outline (quiet mode)",
             "action": "store_true",
@@ -16,7 +16,7 @@ class GroupsListCommand(object):
     }
 
     def run(self, args):
-        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         group_ids = bond.proto.get(bond_id, topic="groups").get("b", {})
         if not args.q:
             print(f"Groups on {bond_id}:")

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -78,7 +78,7 @@ class LivelogCommand(object):
 
         def tear_down_livelog():
             try:
-                stop_livelog(bondid)
+                stop_livelog(bond_id)
                 print("Livelog session stopped")
             except RequestException:
                 pass
@@ -86,26 +86,26 @@ class LivelogCommand(object):
                 print(f"Logs written to {args.out}")
 
         if args.delete:
-            stop_livelog(bondid)
-            bond.proto.delete(bondid, topic="debug/syslog")
-            print(f"Livelog stopped for {bondid}")
+            stop_livelog(bond_id)
+            bond.proto.delete(bond_id, topic="debug/syslog")
+            print(f"Livelog stopped for {bond_id}")
             return
         if args.level:
             bond.proto.patch(
-                bondid, topic="debug/syslog", body={"lvl": LEVEL_MAP[args.level]}
+                bond_id, topic="debug/syslog", body={"lvl": LEVEL_MAP[args.level]}
             )
         if args.subsys:
             body = {"subsys": args.subsys}
             if args.subsys_level:
                 body["lvl"] = LEVEL_MAP[args.subsys_level]
-            bond.proto.patch(bondid, topic="debug/syslog", body=body)
+            bond.proto.patch(bond_id, topic="debug/syslog", body=body)
 
         if args.ip:
             do_livelog(bond, args.ip, int(args.port))
         else:
-            my_ip = get_my_ip(BondDatabase.get_bonds()[bondid]["ip"])
+            my_ip = get_my_ip(BondDatabase.get_bonds()[bond_id]["ip"])
             sock, UDP_PORT = listen(my_ip)
-            do_livelog(bondid, my_ip, UDP_PORT)
+            do_livelog(bond_id, my_ip, UDP_PORT)
         with open(args.out, "w+") as log:
             log.write(f"\n===== {datetime.datetime.now()} =====\n")
             while True:

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -50,6 +50,7 @@ class LivelogCommand(object):
     subcmd = "livelog"
     help = "Start streaming logs"
     arguments = {
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
         "--ip": {"help": "IP of log server"},
         "--port": {"help": "UDP port of log server"},
         "--level": {
@@ -73,7 +74,7 @@ class LivelogCommand(object):
     }
 
     def run(self, args):  # noqa: C901
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
 
         def tear_down_livelog():
             try:

--- a/bond/commands/reboot.py
+++ b/bond/commands/reboot.py
@@ -7,10 +7,13 @@ from bond.database import BondDatabase
 class RebootCommand(object):
     subcmd = "reboot"
     help = """Reboot a Bond. No reset is performed."""
-    arguments = {"--cold": {"help": "simulate cold boot", "action": "store_true"}}
+    arguments = {
+        "--cold": {"help": "simulate cold boot", "action": "store_true"},
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
+    }
 
     def run(self, args):
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bondid = args.bond_id or BondDatabase.get_assert_selected_bondid()
         try:
             body = {}
             if args.cold:

--- a/bond/commands/reset.py
+++ b/bond/commands/reset.py
@@ -17,11 +17,12 @@ class ResetCommand(object):
                        know what you're doing! You probably don't need this unless
                        you're developing firmware for the Bond.""",
             "choices": ["setup", "factory", "rescue"],
-        }
+        },
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bondid = arsg.bond_id or BondDatabase.get_assert_selected_bondid()
         bond.proto.put(bondid, topic="sys/reset", body={"type": args.type})
         # TODO: a response is not expected. When this is fixed in the firmware,
         # check for a success status here

--- a/bond/commands/reset.py
+++ b/bond/commands/reset.py
@@ -22,7 +22,7 @@ class ResetCommand(object):
     }
 
     def run(self, args):
-        bondid = arsg.bond_id or BondDatabase.get_assert_selected_bondid()
+        bondid = args.bond_id or BondDatabase.get_assert_selected_bondid()
         bond.proto.put(bondid, topic="sys/reset", body={"type": args.type})
         # TODO: a response is not expected. When this is fixed in the firmware,
         # check for a success status here

--- a/bond/commands/rfman.py
+++ b/bond/commands/rfman.py
@@ -14,10 +14,11 @@ class RFManCommand(object):
             "help": "Log all signals transmitted by the Bond on BPUP and MQTT transports",
             "action": "store_true",
         },
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bondid = args.bond_id or BondDatabase.get_assert_selected_bondid()
         rsp = bond.proto.patch(
             bondid,
             topic="debug/rfman",

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -26,11 +26,11 @@ class TokenCommand(object):
     help = "Manage token-based authentication."
     arguments = {
         "token": {"help": "Save Bond token to local database", "nargs": "?"},
-        "--bondid": {"help": "ignore selected Bond and use provided"},
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):
-        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         if args.token:
             update_token(args.token, bond_id)
         elif not check_unlocked_token(bond_id):

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -101,11 +101,11 @@ class UpgradeCommand(object):
             "help": "force upgrade with no input from user",
             "action": "store_true",
         },
-        "--bondid": {"help": "ignore selected Bond and use provided"},
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):
-        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         print("Connecting to BOND...")
         sys_version = bond.proto.get(bond_id, topic="sys/version")["b"]
         target = sys_version["target"]

--- a/bond/commands/version.py
+++ b/bond/commands/version.py
@@ -5,10 +5,10 @@ from bond.database import BondDatabase
 class VersionCommand(object):
     subcmd = "version"
     help = "Get firmware version and target of the selected Bond."
-    arguments = {"--bondid": {"help": "ignore selected Bond and use provided"}}
+    arguments = {"--bond-id": {"help": "ignore selected Bond and use provided"}}
 
     def run(self, args):
-        bond_id = args.bondid or BondDatabase.get_assert_selected_bondid()
+        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
         rsp = bond.proto.get(bond_id, topic="sys/version")
         body = rsp.get("b", {})
         print(bond_id)

--- a/bond/commands/wifi.py
+++ b/bond/commands/wifi.py
@@ -13,10 +13,11 @@ class WifiCommand(object):
             "required": True,
         },
         "--password": {"help": "The password", "required": True},
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bondid = arsg.bond_id or BondDatabase.get_assert_selected_bondid()
         rsp = bond.proto.put(
             bondid,
             topic="sys/wifi/sta",
@@ -32,10 +33,12 @@ class WifiCommand(object):
 class WifiShutdownCommand(object):
     subcmd = "wifi_shutdown"
     help = "Shutdown WiFi until reboot (requires fw >= v2.11.4)"
-    arguments = {}
+    arguments = {
+        "--bond-id": {"help": "ignore selected Bond and use provided"},
+    }
 
     def run(self, args):
-        bondid = BondDatabase.get_assert_selected_bondid()
+        bondid = args.bond_id or BondDatabase.get_assert_selected_bondid()
         rsp = bond.proto.patch(
             bondid,
             topic="debug/wifi",

--- a/bond/commands/wifi.py
+++ b/bond/commands/wifi.py
@@ -17,7 +17,7 @@ class WifiCommand(object):
     }
 
     def run(self, args):
-        bondid = arsg.bond_id or BondDatabase.get_assert_selected_bondid()
+        bondid = args.bond_id or BondDatabase.get_assert_selected_bondid()
         rsp = bond.proto.put(
             bondid,
             topic="sys/wifi/sta",


### PR DESCRIPTION
- Allow `--bond-id` argument on `backup`/`livelog`/`reboot`/`reset`/`rfman`/`wifi` commands
- Allow multiple ID arguments on device/group deletion
- Use `kebab-case` on all arguments