### PR TITLE
Distributed groups commands

### DIFF
--- a/bond/app.py
+++ b/bond/app.py
@@ -15,7 +15,7 @@ from bond.commands.signal import SignalCommand
 from bond.commands.token import TokenCommand
 from bond.commands.upgrade import UpgradeCommand
 from bond.commands.version import VersionCommand
-from bond.commands.wifi import WifiCommand
+from bond.commands.wifi import WifiCommand, WifiShutdownCommand
 
 COMMANDS = [
     DiscoverCommand(),
@@ -30,6 +30,7 @@ COMMANDS = [
     ResetCommand(),
     RebootCommand(),
     WifiCommand(),
+    WifiShutdownCommand(),
     UpgradeCommand(),
     RFManCommand(),
     BackupCommand(),

--- a/bond/commands/discover.py
+++ b/bond/commands/discover.py
@@ -18,7 +18,3 @@ class DiscoverCommand(object):
             time.sleep(5)
         except KeyboardInterrupt:
             pass
-
-
-def register():
-    DiscoverCommand()

--- a/bond/commands/groups/__init__.py
+++ b/bond/commands/groups/__init__.py
@@ -3,7 +3,7 @@ from bond.commands.groups import list, create, delete
 
 class GroupsCommand(object):
     subcmd = "groups"
-    help = "Interact with the selected Bond's groups."
+    help = "Interact with device groups."
     subcommands = [
         list.GroupsListCommand(),
         create.GroupCreateCommand(),

--- a/bond/commands/groups/create.py
+++ b/bond/commands/groups/create.py
@@ -1,33 +1,39 @@
+import random
+
 import bond.proto
-from bond.database import BondDatabase
 
 
 class GroupCreateCommand(object):
     subcmd = "create"
     help = "Create a new group."
     arguments = {
+        "devices": {"help": "included devices, in the format BOND_ID:DEVICE_ID", "nargs": "+"},
         "--name": {"help": "group name", "required": True},
-        "--device-ids": {"help": "included devices", "required": True, "nargs": "*"},
         "--group-id": {"help": "predefine group ID (optional)", "required": False},
-        "--bond-id": {"help": "ignore selected Bond and use provided"},
     }
 
     def run(self, args):
-        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
-        create_group_body = {
-            "name": args.name,
-            "devices": args.device_ids,
-        }
+        devices = {}
+        for device in args.devices:
+            bond_id, device_id = device.split(":")
+            devices[bond_id] = devices.get(bond_id, []) + [device_id]
+
+        create_group_body = {"name": args.name}
 
         if args.group_id:
             create_group_body["_id"] = args.group_id
-
-        rsp = bond.proto.post(
-            bond_id,
-            topic="groups",
-            body=create_group_body,
-        )
-        if rsp["s"] > 299:
-            print(f"HTTP {rsp['s']} {rsp['b']['_error_msg']}")
         else:
-            print(f"{rsp['b']['_id']} group created.")
+            uid = f"{random.randrange(2 ** 64):016x}"
+            create_group_body["_id"] = uid
+
+        for bond_id, device_ids in devices.items():
+            create_group_body["devices"] = device_ids
+            rsp = bond.proto.post(
+                bond_id,
+                topic="groups",
+                body=create_group_body,
+            )
+            if rsp["s"] > 299:
+                print(f"HTTP {rsp['s']} {rsp['b']['_error_msg']}")
+            else:
+                print(f"{rsp['b']['_id']} group created in {bond_id}.")

--- a/bond/commands/groups/create.py
+++ b/bond/commands/groups/create.py
@@ -28,12 +28,11 @@ class GroupCreateCommand(object):
 
         for bond_id, device_ids in devices.items():
             create_group_body["devices"] = device_ids
-            rsp = bond.proto.post(
+            bond.proto.request_async(
+                "post",
                 bond_id,
                 topic="groups",
                 body=create_group_body,
+                on_success=lambda b_id, response: print(f"{response['b']['_id']} group created in {b_id}."),
+                on_error=lambda b_id, error_msg: print(f"Error creating group in {b_id}: {error_msg}"),
             )
-            if rsp["s"] > 299:
-                print(f"HTTP {rsp['s']} {rsp['b']['_error_msg']}")
-            else:
-                print(f"{rsp['b']['_id']} group created in {bond_id}.")

--- a/bond/commands/groups/delete.py
+++ b/bond/commands/groups/delete.py
@@ -1,3 +1,5 @@
+from requests.exceptions import ConnectTimeout
+
 import bond.proto
 from bond.database import BondDatabase
 
@@ -22,5 +24,5 @@ class GroupDeleteCommand(object):
                         if args.force or input(f"Delete group {shard_id} from {bond_id}? [N/y] ").lower() == "y":
                             bond.proto.delete(bond_id, topic=f"groups/{shard_id}")
                             print(f"{shard_id} group deleted from {bond_id}.")
-            except Exception:
+            except (ConnectTimeout, PermissionError):
                 pass

--- a/bond/commands/groups/delete.py
+++ b/bond/commands/groups/delete.py
@@ -4,43 +4,23 @@ from bond.database import BondDatabase
 
 class GroupDeleteCommand(object):
     subcmd = "delete"
-    help = "Delete Bond's groups."
+    help = "Delete device group(s)."
     arguments = {
-        "group_ids": {"help": "ID of the group(s) being deleted", "nargs": "*"},
-        "--all": {"help": "delete all groups", "action": "store_true"},
-        "--bond-id": {"help": "ignore selected Bond and use provided"},
+        "group_ids": {"help": "ID of the group(s) being deleted", "nargs": "+"},
         "--force": {
             "help": "force deletion with no input from user",
             "action": "store_true",
         },
     }
 
-    def setup(self, parser):
-        self.parser = parser
-
     def run(self, args):
-        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
-        if args.all:
-            if (
-                args.force
-                or input(f"Delete all groups from {bond_id}? [N/y] ").lower() == "y"
-            ):
-                self.delete_all_groups(bond_id)
-        elif args.group_ids:
-            if (
-                args.force
-                or input(f"Delete group(s) {', '.join(args.group_ids)}? [N/y] ").lower() == "y"
-            ):
-                for group_id in args.group_ids:
-                    bond.proto.delete(bond_id, topic=f"groups/{group_id}")
-                    print(f"{group_id} group deleted.")
-        else:
-            self.parser.print_help()
-
-    def delete_all_groups(self, bond_id):
-        groups_ids = bond.proto.get(bond_id, topic="groups").get("b", {})
-        for group_id in groups_ids:
-            if group_id.startswith("_"):
-                continue
-            bond.proto.delete(bond_id, topic=f"groups/{group_id}")
-            print(f"{group_id} group deleted.")
+        for bond_id in BondDatabase.get_bonds():
+            try:
+                group_shards = bond.proto.get(bond_id, topic="groups").get("b", {})
+                for shard_id in group_shards.keys():
+                    if shard_id in args.group_ids:
+                        if args.force or input(f"Delete group {shard_id} from {bond_id}? [N/y] ").lower() == "y":
+                            bond.proto.delete(bond_id, topic=f"groups/{shard_id}")
+                            print(f"{shard_id} group deleted from {bond_id}.")
+            except Exception:
+                pass

--- a/bond/commands/groups/list.py
+++ b/bond/commands/groups/list.py
@@ -5,10 +5,9 @@ from bond.database import BondDatabase
 
 class GroupsListCommand(object):
     subcmd = "list"
-    help = "List the selected Bond's groups."
+    help = "List device groups."
 
     arguments = {
-        "--bond-id": {"help": "ignore selected Bond and use provided"},
         "-q": {
             "help": "dont print table outline (quiet mode)",
             "action": "store_true",
@@ -16,20 +15,16 @@ class GroupsListCommand(object):
     }
 
     def run(self, args):
-        bond_id = args.bond_id or BondDatabase.get_assert_selected_bondid()
-        group_ids = bond.proto.get(bond_id, topic="groups").get("b", {})
-        if not args.q:
-            print(f"Groups on {bond_id}:")
-        with Table(["group_id", "name", "types", "devices"], quiet=args.q) as table:
-            for group_id in group_ids:
-                if group_id.startswith("_"):
-                    continue
-                group = bond.proto.get(bond_id, topic=f"groups/{group_id}").get("b", {})
-                table.add_row(
-                    {
-                        "group_id": group_id,
-                        "name": group.get("name"),
-                        "types": group.get("types"),
-                        "devices": group.get("devices"),
-                    }
-                )
+        groups = {}
+        for bond_id in BondDatabase.get_bonds():
+            try:
+                group_shards = bond.proto.get(bond_id, topic="groups").get("b", {})
+                for shard_id in group_shards.keys():
+                    if shard_id.startswith("_"):
+                        continue
+                    groups[shard_id] = groups.get(shard_id, []) + [bond_id]
+            except Exception:
+                pass
+        table = Table(["group_id", "bonds"], quiet=args.q)
+        for group, bonds in groups.items():
+            table.add_row({"group_id": group, "bonds": ",".join(bonds)})

--- a/bond/commands/groups/list.py
+++ b/bond/commands/groups/list.py
@@ -1,6 +1,5 @@
 import bond.proto
 from bond.cli.table import Table
-from bond.database import BondDatabase
 
 
 class GroupsListCommand(object):
@@ -15,16 +14,25 @@ class GroupsListCommand(object):
     }
 
     def run(self, args):
-        groups = {}
-        for bond_id in BondDatabase.get_bonds():
-            try:
-                group_shards = bond.proto.get(bond_id, topic="groups").get("b", {})
-                for shard_id in group_shards.keys():
-                    if shard_id.startswith("_"):
-                        continue
-                    groups[shard_id] = groups.get(shard_id, []) + [bond_id]
-            except Exception:
-                pass
         table = Table(["group_id", "bonds"], quiet=args.q)
-        for group, bonds in groups.items():
-            table.add_row({"group_id": group, "bonds": ",".join(bonds)})
+        groups = {}
+
+        for thread in bond.proto.get_all_async(
+            topic="groups",
+            on_success=lambda bond_id, response: include_group_shards(
+                groups, bond_id, response.get("b", {})
+            ),
+            on_error=lambda _bond_id, _error_msg: None,
+        ):
+            thread.join()
+
+        for group_id, bonds in groups.items():
+            table.add_row({"group_id": group_id, "bonds": ",".join(bonds)})
+
+
+def include_group_shards(groups, bond_id, group_shards):
+    group_ids = [
+        group_id for group_id in group_shards.keys() if not group_id.startswith("_")
+    ]
+    for group in group_ids:
+        groups[group] = groups.get(group, []) + [bond_id]

--- a/bond/commands/livelog.py
+++ b/bond/commands/livelog.py
@@ -118,7 +118,3 @@ class LivelogCommand(object):
                 except KeyboardInterrupt:
                     tear_down_livelog()
                     break
-
-
-def register():
-    LivelogCommand()

--- a/bond/commands/reboot.py
+++ b/bond/commands/reboot.py
@@ -21,7 +21,3 @@ class RebootCommand(object):
             bond.proto.put(bondid, topic="sys/reboot", body=body)
         except requests.exceptions.ReadTimeout:
             print("Connection timed out, as expected.")
-
-
-def register():
-    RebootCommand()

--- a/bond/commands/reset.py
+++ b/bond/commands/reset.py
@@ -26,7 +26,3 @@ class ResetCommand(object):
         bond.proto.put(bondid, topic="sys/reset", body={"type": args.type})
         # TODO: a response is not expected. When this is fixed in the firmware,
         # check for a success status here
-
-
-def register():
-    ResetCommand()

--- a/bond/commands/rfman.py
+++ b/bond/commands/rfman.py
@@ -30,7 +30,3 @@ class RFManCommand(object):
         )
         if rsp["s"] > 299:
             print(f"HTTP {rsp['s']} {rsp['b']['_error_msg']}")
-
-
-def register():
-    RFManCommand()

--- a/bond/commands/select.py
+++ b/bond/commands/select.py
@@ -58,7 +58,3 @@ class SelectCommand(object):
             print("Cleared selected Bond")
         else:
             print(f"Bond selected: {BondDatabase().get_assert_selected_bondid()}")
-
-
-def register():
-    SelectCommand()

--- a/bond/commands/signal.py
+++ b/bond/commands/signal.py
@@ -39,7 +39,3 @@ class SignalCommand(object):
         )
         if rsp["s"] > 299:
             print(f"HTTP {rsp['s']} {rsp['b']['_error_msg']}")
-
-
-def register():
-    SignalCommand()

--- a/bond/commands/token.py
+++ b/bond/commands/token.py
@@ -45,7 +45,3 @@ class TokenCommand(object):
                     "You can set it manually with 'bond token <token>', or unlock the token and run 'bond token'"
                 )
                 print("(tip: the token is unlocked for a short period after a reboot)")
-
-
-def register():
-    TokenCommand()

--- a/bond/commands/upgrade.py
+++ b/bond/commands/upgrade.py
@@ -8,10 +8,6 @@ import bond.proto
 from bond.database import BondDatabase
 
 
-def register():
-    UpgradeCommand()
-
-
 def get_branch_string(branch, target):
     if branch in ("alpha", "beta", "master"):
         return f"{branch}-{target}"

--- a/bond/commands/version.py
+++ b/bond/commands/version.py
@@ -14,7 +14,3 @@ class VersionCommand(object):
         print(bond_id)
         print(f"Target: {body.get('target')}")
         print(f"Version: {body.get('fw_ver')}")
-
-
-def register():
-    VersionCommand()

--- a/bond/commands/wifi.py
+++ b/bond/commands/wifi.py
@@ -46,8 +46,3 @@ class WifiShutdownCommand(object):
         )
         if rsp["s"] > 299:
             print(f"HTTP {rsp['s']} {rsp['b']['_error_msg']}")
-
-
-def register():
-    WifiCommand()
-    WifiShutdownCommand()

--- a/bond/proto/__init__.py
+++ b/bond/proto/__init__.py
@@ -1,1 +1,1 @@
-from bond.proto.wye import get, put, post, patch, delete, get_all_async, get_async  # noqa: F401
+from bond.proto.wye import get, put, post, patch, delete, get_all_async, request_async  # noqa: F401

--- a/bond/proto/base_transport.py
+++ b/bond/proto/base_transport.py
@@ -1,23 +1,19 @@
-from collections import defaultdict
 from threading import Thread
 
 
 class BaseTransport(object):
-    def get_async(self, *args, **kwargs):
-        kwargs = defaultdict(lambda: lambda x: {}, kwargs)
-        on_success = kwargs["on_success"]
-        del kwargs["on_success"]
-        on_error = kwargs["on_error"]
-        del kwargs["on_error"]
+    def request_async(self, http_method_name, *args, **kwargs):
+        on_success = kwargs.pop("on_success")
+        on_error = kwargs.pop("on_error")
 
         def task():
             try:
-                on_success(self.bondid, self.get(*args, **kwargs))
+                on_success(
+                    self.bondid, getattr(self, http_method_name)(*args, **kwargs)
+                )
             except Exception as e:
                 on_error(self.bondid, e)
 
         t = Thread(target=task)
         t.start()
         return t
-
-    # TODO: other methods

--- a/bond/proto/http.py
+++ b/bond/proto/http.py
@@ -50,5 +50,5 @@ class HTTP_Transport(BaseTransport):
         except:  # noqa: E722 - ignore bare except
             body = None
         if rsp.status_code == 401:
-            raise SystemExit("Invalid token! Have you set it with 'bond token' yet?")
+            raise PermissionError("Invalid token! Have you set it with 'bond token' yet?")
         return {"s": rsp.status_code, "b": body, "bondid": self.bondid}


### PR DESCRIPTION
## Description
`bond groups` commands now support multiple-Bond groups.
It starts a new asynchronous `Thread` for each Bond that it needs to communicate within a command, for optimized execution time.
For groups discovery (`bond groups list`), all Bonds previously discovered are sent a request, with a new `Thread` each.

## Usage
```shell
> bond groups
usage: bond groups [-h] {list,create,delete} ...

positional arguments:
  {list,create,delete}
    list                List device groups.
    create              Create a new group.
    delete              Delete device group(s).

options:
  -h, --help            show this help message and exit
```

### Group discovery
```shell
> bond groups list -h
usage: bond groups list [-h] [-q]

options:
  -h, --help  show this help message and exit
  -q          dont print table outline (quiet mode)
```

Example:
```shell
> bond groups list
-------------------------------------------
|group_id            |bonds               |
|--------------------|--------------------|
|abcdef1234567890    |ZZDI37978,ZPEA77129 |
-------------------------------------------
```

### Group creation
```shell
> bond groups create -h
usage: bond groups create [-h] --name NAME [--group-id GROUP_ID] devices [devices ...]
bond groups create: error: the following arguments are required: devices, --name
```

A `device` must be declared in the format `BOND_ID:DEVICE_ID`.

Example:
```shell
> bond groups create --name "DGroup" ZPEA77129:766a5b81 ZZDI37978:65df4c1f6da05631 INVALID-BOND:INVALID-DEVICE --group-id 1122334455667788
Error creating group in INVALID-BOND: INVALID-BOND hasn't been discovered by bond-cli ('bond discover').
1122334455667788 group created in ZZDI37978.
1122334455667788 group created in ZPEA77129.
```

### Group deletion
```shell
> bond groups delete -h
usage: bond groups delete [-h] [--force] group_ids [group_ids ...]
bond groups delete: error: the following arguments are required: group_ids
```

Example:
```shell
> bond groups delete 1122334455667788
Delete group(s) 1122334455667788? [N/y] y
1122334455667788 group deleted from ZPEA77129.
1122334455667788 group deleted from ZZDI37978.
```

## Additional changes:
- Reintroduces missing `wifi_shutdown` command