### PR TITLE
Display selected bond upon list command

### DIFF
--- a/bond/cli/table.py
+++ b/bond/cli/table.py
@@ -12,7 +12,7 @@ class Table(object):
         self.print_header()
 
     def print_tabbed(self, lst):
-        separator = "" if self.quiet else "|"
+        separator = "" if self.quiet else "| "
 
         print("", end=separator)
 
@@ -23,14 +23,18 @@ class Table(object):
 
     def print_border(self):
         if not self.quiet:
-            print("-" * ((self.col_width + 1) * len(self.header) + 1))
+            print(" " + "-" * ((self.col_width + 1) * len(self.header) + 2))
 
     def print_header(self):
-        self.print_border()
+        if not self.quiet:
+            self.print_border()
+
         self.print_tabbed(self.header)
 
         if not self.quiet:
-            self.print_tabbed([("-" * self.col_width) for _h in self.header])
+            self.print_tabbed(
+                [("-" * (self.col_width - 1)) + " " for _h in self.header]
+            )
 
     def add_row(self, row):
         if self.open:

--- a/bond/commands/list.py
+++ b/bond/commands/list.py
@@ -17,8 +17,18 @@ class BondListCommand(object):
         else:
             table = Table(["bondid", "ip", "token"], quiet=args.q)
             bonds = BondDatabase.get_bonds()
+            selected_bond = BondDatabase().get("selected_bondid")
             for bondid in bonds.keys():
                 b = bonds[bondid]
+                bond_id_display = (
+                    bondid + " <-----"
+                    if not args.q and bondid == selected_bond
+                    else bondid
+                )
                 table.add_row(
-                    {"bondid": bondid, "ip": b.get("ip"), "token": b.get("token")}
+                    {
+                        "bondid": bond_id_display,
+                        "ip": b.get("ip"),
+                        "token": b.get("token"),
+                    }
                 )


### PR DESCRIPTION
Adds an arrow displaying the selected Bond (if any) when running `bond list` command:

```shell
> bond list
 -----------------------------------------------------------------
| bondid              | ip                  | token               |
| ------------------- | ------------------- | ------------------- |
| ZPEA77129           | 192.168.1.11        | None                |
| ZZDI37978 <-----    | 192.168.1.14        | None                |
 -----------------------------------------------------------------
```

If ran with the quiet flag (`-q`), the arrow is omitted:
```shell
> bond list -q
bondid              ip                  token
ZPEA77000           192.168.1.11        None
ZZDI37333           192.168.1.13        None
```