### PR TITLE
Add __main__

### DIFF
--- a/bond/__main__.py
+++ b/bond/__main__.py
@@ -1,0 +1,8 @@
+from bond import app
+from bond.cli.console import console_terminate
+
+if __name__ == "__main__":
+    try:
+        app.run()
+    finally:
+        console_terminate()


### PR DESCRIPTION
The `bond/__main__.py` was wrongfully deleted when refactoring into subcommands (a99cf55).
This adds the file back, allowing for `python -m bond` to be used again.