### PR TITLE
add sync command

### DIFF
--- a/bond/app.py
+++ b/bond/app.py
@@ -2,6 +2,7 @@ import sys
 
 from bond.cli.main import load_commands, execute_from_command_line
 from bond.commands.backup import BackupCommand, RestoreCommand
+from bond.commands.sync import SyncCommand
 from bond.commands.devices import DevicesCommand
 from bond.commands.discover import DiscoverCommand
 from bond.commands.groups import GroupsCommand
@@ -18,6 +19,7 @@ from bond.commands.version import VersionCommand
 from bond.commands.wifi import WifiCommand
 
 COMMANDS = [
+    SyncCommand(),
     DiscoverCommand(),
     SelectCommand(),
     VersionCommand(),

--- a/bond/commands/sync.py
+++ b/bond/commands/sync.py
@@ -1,0 +1,97 @@
+import bond.proto
+from bond.database import BondDatabase
+import json
+import os
+from pprint import pprint
+
+
+def drop_shadow(bondid):
+    bond_entry = BondDatabase.get("bonds")[bondid]
+    if 'shadow' in bond_entry:
+        del bond_entry['shadow']
+    BondDatabase.set("bonds", BondDatabase.get("bonds"))
+
+
+def sync(bondid, verbose=False):
+    bond_entry = BondDatabase.get("bonds")[bondid]
+    if 'shadow' not in bond_entry:
+        bond_entry['shadow'] = {}
+    shadow = bond_entry['shadow']
+
+    # returns list of subtopics that have different hashes ('_')
+    def update_shadow(topic, body, verbose=False):
+        if not verbose:
+            print = lambda *args, **kwargs: None
+        else:
+            print = __builtins__['print']
+        d = shadow
+        if topic:
+            parts = topic.split('/')
+            for p in parts:
+                d = d.setdefault(p, {})
+        rv = []
+        # find hashes of children that have changed
+        for k, v in body.items():
+            # local fields are directly updated
+            if k.startswith('_') or not isinstance(v, dict) or '_' not in v:
+                d[k] = v
+                continue
+            # new children are added
+            if k not in d:
+                print(f"  new:{k}", end='')
+                d[k] = v
+                rv.append(k)
+            # children with changed hashes are updated
+            if d[k]['_'] != v['_']:
+                d[k]['_'] = v['_']
+                rv.append(k)
+        # children that have been removed are deleted
+        for k in list(d.keys()):
+            if k not in body:
+                print(f"  del:{k}", end='')
+                del d[k]
+        print()
+        return rv
+
+    def walk(topic):
+        topic = topic.strip('/')
+        rsp = bond.proto.get(bondid, topic=topic)
+        if rsp['s'] >= 300:
+            print(f"HTTP {rsp['s']} {topic}")
+            return
+        body = rsp['b']
+        if verbose:
+            print(f"GET {topic}...", end='')
+        if isinstance(body, dict):
+            changed_children = update_shadow(topic, body, verbose=verbose)
+            for k in changed_children:
+                walk(f"{topic}/{k}")
+    walk('')
+    BondDatabase.set("bonds", BondDatabase.get("bonds"))
+
+
+class SyncCommand(object):
+    subcmd = "sync"
+    help = "Update local database for selected Bond"
+    arguments = {
+        "--verbose": {
+            "help": "Print out all the details of the sync",
+            "action": "store_true",
+        },
+        "--full": {
+            "help": "Re-sync everything, not just the delta",
+            "action": "store_true",
+        },
+        "--print": {
+            "help": "Print out the shadow after syncing",
+            "action": "store_true",
+        },
+    }
+
+    def run(self, args):
+        bondid = BondDatabase.get_assert_selected_bondid()
+        if args.full:
+            drop_shadow(bondid)
+        sync(bondid, verbose=args.verbose)
+        if args.print:
+            pprint(BondDatabase.get("bonds")[bondid]['shadow'])

--- a/bond/database/database.py
+++ b/bond/database/database.py
@@ -81,3 +81,7 @@ class BondDatabase(MutableMapping):
     @staticmethod
     def set(key, value):
         BondDatabase()[key] = value
+
+    @staticmethod
+    def get(key):
+        return BondDatabase()[key]

--- a/bond/database/database.py
+++ b/bond/database/database.py
@@ -85,3 +85,7 @@ class BondDatabase(MutableMapping):
     @staticmethod
     def get(key):
         return BondDatabase()[key]
+    
+    @staticmethod
+    def get_shadow(bondid):
+        return BondDatabase().get_bond(bondid).get("shadow", dict())


### PR DESCRIPTION

```bash
$ python -m bond sync -h
usage: bond sync [-h] [--verbose] [--full] [--print]

options:
  -h, --help  show this help message and exit
  --verbose   Print out all the details of the sync
  --full      Re-sync everything, not just the delta
  --print     Print out the shadow after syncing
```

Supports incremental update using hash tree:

```bash
$ python -m bond sync --verbose
GET ...
GET devices...
GET devices/1...
GET devices/1/skeds...  new:ddf10dc2175096f3  del:f71ba149d50f6ec0
GET devices/1/skeds/ddf10dc2175096f3...
```